### PR TITLE
feat: Docker CI 和 GHCR 镜像构建流程

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.git
+.context
+*.pen
+.env
+.env.local
+*.local
+packages/app
+docs

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,69 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/thup-jds/pet-wechat
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/server
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: packages/server/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-admin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/admin
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: packages/admin/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       POSTGRES_DB: pet_wechat
     volumes:
       - pg_data:/var/lib/postgresql/data
+
   minio:
     image: minio/minio
     ports:
@@ -20,6 +21,31 @@ services:
     command: server /data --console-address :9001
     volumes:
       - minio_data:/data
+
+  server:
+    image: ghcr.io/thup-jds/pet-wechat/server:latest
+    ports:
+      - "9527:9527"
+    environment:
+      DATABASE_URL: postgres://pet:pet123@postgres:5432/pet_wechat
+      S3_ENDPOINT: http://minio:9000
+      S3_PUBLIC_URL: http://localhost:9000
+      S3_ACCESS_KEY: minioadmin
+      S3_SECRET_KEY: minioadmin
+      S3_BUCKET: pet-wechat
+      # TODO: 生产环境需替换为安全的密钥
+      JWT_SECRET: yehey-dev-secret-change-in-prod
+      ADMIN_KEY: yehey-admin-dev
+    depends_on:
+      - postgres
+      - minio
+
+  admin:
+    image: ghcr.io/thup-jds/pet-wechat/admin:latest
+    ports:
+      - "80:80"
+    depends_on:
+      - server
 
 volumes:
   pg_data:

--- a/packages/admin/Dockerfile
+++ b/packages/admin/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:20-alpine AS base
+RUN corepack enable && corepack prepare pnpm@10.28.1 --activate
+WORKDIR /app
+
+FROM base AS install
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY packages/shared/package.json ./packages/shared/
+COPY packages/admin/package.json ./packages/admin/
+RUN pnpm install --frozen-lockfile
+
+FROM base AS build
+COPY --from=install /app/node_modules ./node_modules
+COPY --from=install /app/packages/admin/node_modules ./packages/admin/node_modules
+COPY --from=install /app/packages/shared/node_modules ./packages/shared/node_modules
+COPY packages/shared ./packages/shared
+COPY packages/admin ./packages/admin
+WORKDIR /app/packages/admin
+RUN pnpm build
+
+FROM nginx:alpine
+COPY --from=build /app/packages/admin/dist /usr/share/nginx/html
+COPY packages/admin/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/packages/admin/nginx.conf
+++ b/packages/admin/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://server:9527;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:20-alpine AS base
+RUN corepack enable && corepack prepare pnpm@10.28.1 --activate
+WORKDIR /app
+
+FROM base AS install
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY packages/shared/package.json ./packages/shared/
+COPY packages/server/package.json ./packages/server/
+RUN pnpm install --frozen-lockfile
+
+FROM oven/bun:1-alpine
+WORKDIR /app
+COPY --from=install /app/node_modules ./node_modules
+COPY --from=install /app/packages/server/node_modules ./packages/server/node_modules
+COPY --from=install /app/packages/shared/node_modules ./packages/shared/node_modules
+COPY packages/shared ./packages/shared
+COPY packages/server ./packages/server
+
+WORKDIR /app/packages/server
+EXPOSE 9527
+CMD ["bun", "src/index.ts"]


### PR DESCRIPTION
## Summary
创建完整的 Docker 构建和部署流程，为后端和管理后台构建容器镜像并推送到 GHCR。包括 GitHub Actions CI workflow、多阶段 Dockerfile 和更新的 docker-compose 配置。

## Changes
- **CI Pipeline**: 创建 `.github/workflows/build-images.yml` 自动构建并推送 server 和 admin 镜像到 GHCR（提交 SHA 和 latest 标签）
- **Server Dockerfile**: 使用 pnpm 安装依赖，Bun 作为运行时，配置数据库和 S3 连接
- **Admin Dockerfile**: 三层构建（安装 → 编译 → nginx 服务），pnpm@10.28.1 固定版本确保构建可重现
- **Nginx 配置**: 实现 SPA 路由和 API 反向代理到后端服务
- **Docker Compose**: 更新为使用 GHCR 镜像，配置完整的 S3/MinIO 环境变量支持文件上传

## Notes
- Adversarial review 已验证并修复所有高优先级问题（S3 连接、pnpm 版本固定等）
- 开发环境凭据使用默认值，生产环境需替换（已标注 TODO）

🤖 Generated with [Claude Code](https://claude.com/claude-code)