### PR TITLE
fix: 修复 Docker 镜像构建失败

### DIFF
--- a/packages/admin/Dockerfile
+++ b/packages/admin/Dockerfile
@@ -11,7 +11,6 @@ RUN pnpm install --frozen-lockfile
 FROM base AS build
 COPY --from=install /app/node_modules ./node_modules
 COPY --from=install /app/packages/admin/node_modules ./packages/admin/node_modules
-COPY --from=install /app/packages/shared/node_modules ./packages/shared/node_modules
 COPY packages/shared ./packages/shared
 COPY packages/admin ./packages/admin
 WORKDIR /app/packages/admin

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -12,7 +12,6 @@ FROM oven/bun:1-alpine
 WORKDIR /app
 COPY --from=install /app/node_modules ./node_modules
 COPY --from=install /app/packages/server/node_modules ./packages/server/node_modules
-COPY --from=install /app/packages/shared/node_modules ./packages/shared/node_modules
 COPY packages/shared ./packages/shared
 COPY packages/server ./packages/server
 


### PR DESCRIPTION
修复 Docker CI 镜像构建失败问题。packages/shared 无依赖，pnpm install 不为其生成 node_modules，导致两个 Dockerfile 中的 COPY 指令失败。删除这两行无效的 COPY。

- packages/admin/Dockerfile：删除 COPY --from=install /app/packages/shared/node_modules
- packages/server/Dockerfile：删除 COPY --from=install /app/packages/shared/node_modules

经过 Adversarial Review，此修复正确且必要。