### PR TITLE
[codex] Polish admin backoffice pages

### DIFF
--- a/packages/admin/src/App.tsx
+++ b/packages/admin/src/App.tsx
@@ -40,9 +40,9 @@ const menuItems: MenuProps["items"] = [
       { key: "/schedules", icon: <CalendarOutlined />, label: "行为日程" },
       { key: "/image-review", icon: <PictureOutlined />, label: "图像审核" },
       { key: "/customization", icon: <ScissorOutlined />, label: "定制中心" },
-      { key: "/devices", icon: <MobileOutlined />, label: "设备管理" },
       { key: "/analytics", icon: <BarChartOutlined />, label: "数据看板" },
-      { key: "/users", icon: <UserOutlined />, label: "用户管理" },
+      { key: "/devices", icon: <MobileOutlined />, label: "设备管理" },
+      { key: "/users", icon: <UserOutlined />, label: "用户会员" },
     ],
   },
   {

--- a/packages/admin/src/pages/Customization.tsx
+++ b/packages/admin/src/pages/Customization.tsx
@@ -1,19 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { CheckOutlined, DeleteOutlined, SyncOutlined, UploadOutlined } from "@ant-design/icons";
 import {
-  Badge,
   Button,
   Card,
-  Col,
   Empty,
   Image,
   Input,
   Modal,
-  Row,
-  Select,
+  Progress,
+  Segmented,
+  Space,
   Spin,
-  Statistic,
   Tag,
+  Typography,
   message,
 } from "antd";
 import {
@@ -21,21 +20,28 @@ import {
   BASIC_ACTIONS,
   FUN_ACTIONS,
   type ActionType,
+  type Gender,
   type Pet,
   type PetAvatar,
   type PetAvatarAction,
   type Species,
   type User,
 } from "shared";
+import dayjs from "dayjs";
 import { api } from "../api/client";
 
+const { Text, Title } = Typography;
+
 type CustomizationStatus = "approved" | "processing" | "done";
-type TaskFilter = "all" | CustomizationStatus;
+type TaskTab = "pending" | "done";
+type CategoryFilter = "all" | "basic" | "fun";
 
 type CustomizationAvatar = PetAvatar & {
-  pet: (Pick<Pet, "id" | "name"> & {
-    species: Species | "other" | string | null;
-  }) | null;
+  pet:
+    | (Pick<Pet, "id" | "name" | "species" | "breed" | "gender" | "birthday"> & {
+        species: Species | "other" | string | null;
+      })
+    | null;
   user: Pick<User, "id" | "nickname" | "avatarUrl" | "wechatOpenid" | "phone"> | null;
 };
 
@@ -47,14 +53,18 @@ type CustomizationAction = PetAvatarAction & {
   actionType: ActionType;
 };
 
+type CategoryProgress = {
+  completed: number;
+  total: number;
+};
+
 const TASK_STATUSES: CustomizationStatus[] = ["approved", "processing", "done"];
 
-const filterOptions: Array<{ label: string; value: TaskFilter }> = [
-  { label: "全部", value: "all" },
-  { label: "待定制", value: "approved" },
-  { label: "进行中", value: "processing" },
-  { label: "已完成", value: "done" },
-];
+const categoryOptions = [
+  { label: "全部图像类别", value: "all" },
+  { label: "基础动作", value: "basic" },
+  { label: "个性化动作", value: "fun" },
+] satisfies { label: string; value: CategoryFilter }[];
 
 const statusMeta: Record<CustomizationStatus, { label: string; color: string }> = {
   approved: { label: "待定制", color: "blue" },
@@ -66,6 +76,12 @@ const speciesLabels: Record<string, string> = {
   cat: "猫",
   dog: "狗",
   other: "其他",
+};
+
+const genderLabels: Record<Gender, string> = {
+  male: "公",
+  female: "母",
+  unknown: "未知",
 };
 
 function padNumber(value: number) {
@@ -107,6 +123,42 @@ function getSpeciesLabel(species?: string | null) {
   return speciesLabels[species] ?? species;
 }
 
+function getGenderLabel(gender?: string | null) {
+  if (!gender) {
+    return "未知";
+  }
+
+  return genderLabels[gender as Gender] ?? "未知";
+}
+
+function getAgeLabel(birthday?: string | null) {
+  if (!birthday) {
+    return "未知";
+  }
+
+  const birth = dayjs(birthday);
+  if (!birth.isValid() || birth.isAfter(dayjs())) {
+    return "未知";
+  }
+
+  const months = dayjs().diff(birth, "month");
+  if (months < 12) {
+    return `${Math.max(1, months)}个月`;
+  }
+
+  const years = dayjs().diff(birth, "year");
+  return `${years}岁`;
+}
+
+function formatDate(value?: string | null) {
+  if (!value) {
+    return "-";
+  }
+
+  const parsed = dayjs(value);
+  return parsed.isValid() ? parsed.format("YYYY-MM-DD") : "-";
+}
+
 function buildActionMap(actions: PetAvatarAction[]) {
   return actions.reduce<Record<string, CustomizationAction>>((map, action) => {
     map[action.actionType] = action as CustomizationAction;
@@ -114,14 +166,226 @@ function buildActionMap(actions: PetAvatarAction[]) {
   }, {});
 }
 
+function countCompletedActions(actions: PetAvatarAction[], actionTypes: readonly ActionType[]) {
+  const actionTypeSet = new Set(actionTypes);
+  return actions.filter((action) => actionTypeSet.has(action.actionType as ActionType)).length;
+}
+
+function getCategoryProgress(actions: PetAvatarAction[], category: CategoryFilter): CategoryProgress {
+  if (category === "basic") {
+    return {
+      completed: countCompletedActions(actions, BASIC_ACTIONS),
+      total: BASIC_ACTIONS.length,
+    };
+  }
+
+  if (category === "fun") {
+    return {
+      completed: countCompletedActions(actions, FUN_ACTIONS),
+      total: FUN_ACTIONS.length,
+    };
+  }
+
+  return {
+    completed: actions.length,
+    total: BASIC_ACTIONS.length + FUN_ACTIONS.length,
+  };
+}
+
+function getCategoryStatusTag(progress: CategoryProgress) {
+  if (progress.completed === 0) {
+    return { label: "待定制", color: "blue" };
+  }
+
+  if (progress.completed >= progress.total) {
+    return { label: "已完成", color: "green" };
+  }
+
+  return { label: "进行中", color: "orange" };
+}
+
+function getStatusMetaForAvatarStatus(status: CustomizationStatus) {
+  return statusMeta[status];
+}
+
+function getDefaultPreviewActionType(actions: PetAvatarAction[]) {
+  if (actions.length === 0) {
+    return null;
+  }
+
+  return actions[0].actionType as ActionType;
+}
+
+function buildMockImageUrl(title: string, accent: string, subtitle: string) {
+  const svg = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1200" viewBox="0 0 1200 1200">
+      <defs>
+        <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stop-color="${accent}" stop-opacity="0.95" />
+          <stop offset="100%" stop-color="#fff7e6" stop-opacity="1" />
+        </linearGradient>
+      </defs>
+      <rect width="1200" height="1200" fill="url(#bg)" />
+      <circle cx="930" cy="220" r="150" fill="#ffffff" fill-opacity="0.25" />
+      <circle cx="250" cy="910" r="200" fill="#ffffff" fill-opacity="0.18" />
+      <rect x="120" y="160" width="960" height="880" rx="52" fill="#ffffff" fill-opacity="0.72" />
+      <text x="180" y="430" font-size="88" font-family="Arial, sans-serif" font-weight="700" fill="#1f1f1f">${title}</text>
+      <text x="180" y="540" font-size="40" font-family="Arial, sans-serif" fill="#434343">${subtitle}</text>
+      <text x="180" y="640" font-size="30" font-family="Arial, sans-serif" fill="#595959">Customization Demo</text>
+    </svg>
+  `;
+
+  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+}
+
+function toCustomizationAvatarSummary(avatar: CustomizationAvatarDetail): CustomizationAvatar {
+  const { actions: _actions, ...summary } = avatar;
+  return summary;
+}
+
+function createMockCustomizationDetails(): CustomizationAvatarDetail[] {
+  return [
+    {
+      id: "mock-custom-avatar-1",
+      petId: "mock-custom-pet-1",
+      sourceImageUrl: buildMockImageUrl("布丁", "#ffd666", "待定制 · 今日新增"),
+      status: "approved",
+      rejectReason: null,
+      reviewedAt: dayjs().subtract(30, "minute").toISOString(),
+      createdAt: dayjs().subtract(2, "hour").toISOString(),
+      pet: {
+        id: "mock-custom-pet-1",
+        name: "布丁",
+        species: "cat",
+        breed: "英短",
+        gender: "female",
+        birthday: dayjs().subtract(8, "month").format("YYYY-MM-DD"),
+      },
+      user: {
+        id: "mock-custom-user-1",
+        nickname: "Momo",
+        avatarUrl: null,
+        wechatOpenid: "mock-custom-openid-1",
+        phone: "13800000011",
+      },
+      actions: [],
+    },
+    {
+      id: "mock-custom-avatar-2",
+      petId: "mock-custom-pet-2",
+      sourceImageUrl: buildMockImageUrl("栗子", "#95de64", "进行中 · 基础动作"),
+      status: "processing",
+      rejectReason: null,
+      reviewedAt: dayjs().subtract(4, "hour").toISOString(),
+      createdAt: dayjs().subtract(6, "hour").toISOString(),
+      pet: {
+        id: "mock-custom-pet-2",
+        name: "栗子",
+        species: "dog",
+        breed: "柯基",
+        gender: "male",
+        birthday: dayjs().subtract(2, "year").format("YYYY-MM-DD"),
+      },
+      user: {
+        id: "mock-custom-user-2",
+        nickname: "Cookie",
+        avatarUrl: null,
+        wechatOpenid: "mock-custom-openid-2",
+        phone: "13800000012",
+      },
+      actions: [
+        {
+          id: "mock-custom-action-1",
+          petAvatarId: "mock-custom-avatar-2",
+          actionType: "sit",
+          imageUrl: buildMockImageUrl("栗子", "#b7eb8f", "基础动作 · sit"),
+          sortOrder: 0,
+        },
+        {
+          id: "mock-custom-action-2",
+          petAvatarId: "mock-custom-avatar-2",
+          actionType: "eat",
+          imageUrl: buildMockImageUrl("栗子", "#d9f7be", "基础动作 · eat"),
+          sortOrder: 1,
+        },
+        {
+          id: "mock-custom-action-3",
+          petAvatarId: "mock-custom-avatar-2",
+          actionType: "play_ball",
+          imageUrl: buildMockImageUrl("栗子", "#73d13d", "个性化动作 · play_ball"),
+          sortOrder: 2,
+        },
+      ],
+    },
+    {
+      id: "mock-custom-avatar-3",
+      petId: "mock-custom-pet-3",
+      sourceImageUrl: buildMockImageUrl("可颂", "#69b1ff", "已完成 · 同步到手机端"),
+      status: "done",
+      rejectReason: null,
+      reviewedAt: dayjs().subtract(1, "day").add(3, "hour").toISOString(),
+      createdAt: dayjs().subtract(2, "day").toISOString(),
+      pet: {
+        id: "mock-custom-pet-3",
+        name: "可颂",
+        species: "dog",
+        breed: "比熊",
+        gender: "female",
+        birthday: dayjs().subtract(1, "year").subtract(3, "month").format("YYYY-MM-DD"),
+      },
+      user: {
+        id: "mock-custom-user-3",
+        nickname: "Luna",
+        avatarUrl: null,
+        wechatOpenid: "mock-custom-openid-3",
+        phone: "13800000013",
+      },
+      actions: [
+        ...BASIC_ACTIONS.map((actionType, index) => ({
+          id: `mock-custom-action-basic-${index + 1}`,
+          petAvatarId: "mock-custom-avatar-3",
+          actionType,
+          imageUrl: buildMockImageUrl("可颂", "#91caff", `基础动作 · ${ACTION_LABELS[actionType] ?? actionType}`),
+          sortOrder: index,
+        })),
+        ...FUN_ACTIONS.slice(0, 2).map((actionType, index) => ({
+          id: `mock-custom-action-fun-${index + 1}`,
+          petAvatarId: "mock-custom-avatar-3",
+          actionType,
+          imageUrl: buildMockImageUrl("可颂", "#adc6ff", `个性化动作 · ${ACTION_LABELS[actionType] ?? actionType}`),
+          sortOrder: BASIC_ACTIONS.length + index,
+        })),
+      ],
+    },
+  ];
+}
+
+function applyDemoDataState(
+  setDemoAvatarDetails: (details: CustomizationAvatarDetail[]) => void,
+  setAvatars: (avatars: CustomizationAvatar[]) => void,
+  setIsDemoMode: (value: boolean) => void,
+) {
+  const nextDemoDetails = createMockCustomizationDetails();
+  setDemoAvatarDetails(nextDemoDetails);
+  setAvatars(nextDemoDetails.map(toCustomizationAvatarSummary));
+  setIsDemoMode(true);
+  return nextDemoDetails;
+}
+
+const initialDemoDetails = createMockCustomizationDetails();
+
 export default function Customization() {
   const [messageApi, contextHolder] = message.useMessage();
-  const [avatars, setAvatars] = useState<CustomizationAvatar[]>([]);
+  const [avatars, setAvatars] = useState<CustomizationAvatar[]>(() => initialDemoDetails.map(toCustomizationAvatarSummary));
+  const [demoAvatarDetails, setDemoAvatarDetails] = useState<CustomizationAvatarDetail[]>(() => initialDemoDetails);
+  const [isDemoMode, setIsDemoMode] = useState(true);
   const [loading, setLoading] = useState(false);
-  const [filter, setFilter] = useState<TaskFilter>("all");
+  const [taskTab, setTaskTab] = useState<TaskTab>("pending");
+  const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>("all");
   const [selectedAvatarId, setSelectedAvatarId] = useState<string | null>(null);
   const [selectedAvatarDetail, setSelectedAvatarDetail] = useState<CustomizationAvatarDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
+  const [previewActionType, setPreviewActionType] = useState<ActionType | null>(null);
   const [uploadModalOpen, setUploadModalOpen] = useState(false);
   const [uploadActionType, setUploadActionType] = useState<ActionType | null>(null);
   const [uploadImageUrl, setUploadImageUrl] = useState("");
@@ -135,9 +399,22 @@ export default function Customization() {
 
     try {
       const response = await api.getAvatars();
-      setAvatars(((response.avatars as CustomizationAvatar[]) ?? []).filter((avatar) => TASK_STATUSES.includes(avatar.status as CustomizationStatus)));
+      const nextAvatars = ((response.avatars as CustomizationAvatar[]) ?? []).filter((avatar) =>
+        TASK_STATUSES.includes(avatar.status as CustomizationStatus),
+      );
+
+      if (nextAvatars.length === 0) {
+        applyDemoDataState(setDemoAvatarDetails, setAvatars, setIsDemoMode);
+        messageApi.warning("未获取到真实定制任务，当前展示演示数据");
+        return;
+      }
+
+      setIsDemoMode(false);
+      setDemoAvatarDetails([]);
+      setAvatars(nextAvatars);
     } catch (error) {
-      messageApi.error(error instanceof Error ? error.message : "定制任务加载失败");
+      applyDemoDataState(setDemoAvatarDetails, setAvatars, setIsDemoMode);
+      messageApi.warning("定制任务加载失败，当前展示演示数据");
     } finally {
       setLoading(false);
     }
@@ -145,6 +422,19 @@ export default function Customization() {
 
   const loadAvatarDetail = async (avatarId: string, options?: { keepLoading?: boolean }) => {
     const requestId = ++detailRequestRef.current;
+
+    if (isDemoMode) {
+      const detail = demoAvatarDetails.find((avatar) => avatar.id === avatarId) ?? null;
+      setSelectedAvatarDetail(detail);
+      setPreviewActionType((current) => {
+        if (current && detail?.actions.some((action) => action.actionType === current)) {
+          return current;
+        }
+
+        return detail ? getDefaultPreviewActionType(detail.actions) : null;
+      });
+      return detail;
+    }
 
     if (!options?.keepLoading) {
       setDetailLoading(true);
@@ -156,12 +446,20 @@ export default function Customization() {
 
       if (detailRequestRef.current === requestId) {
         setSelectedAvatarDetail(detail);
+        setPreviewActionType((current) => {
+          if (current && detail.actions.some((action) => action.actionType === current)) {
+            return current;
+          }
+
+          return getDefaultPreviewActionType(detail.actions);
+        });
       }
 
       return detail;
     } catch (error) {
       if (detailRequestRef.current === requestId) {
         setSelectedAvatarDetail(null);
+        setPreviewActionType(null);
       }
 
       messageApi.error(error instanceof Error ? error.message : "定制详情加载失败");
@@ -177,28 +475,43 @@ export default function Customization() {
     void loadAvatars();
   }, []);
 
-  const filteredAvatars = useMemo(() => {
-    if (filter === "all") {
-      return avatars;
-    }
-
-    return avatars.filter((avatar) => avatar.status === filter);
-  }, [avatars, filter]);
-
-  const totalDoneCount = useMemo(
-    () => avatars.filter((avatar) => avatar.status === "done").length,
+  const pendingAvatars = useMemo(
+    () => avatars.filter((avatar) => avatar.status === "approved" || avatar.status === "processing"),
     [avatars],
   );
 
-  const todayNewApprovedCount = useMemo(
-    () => avatars.filter((avatar) => enteredCustomizationToday(avatar)).length,
+  const doneAvatars = useMemo(
+    () => avatars.filter((avatar) => avatar.status === "done"),
     [avatars],
+  );
+
+  const todayNewPendingCount = useMemo(
+    () => pendingAvatars.filter((avatar) => enteredCustomizationToday(avatar)).length,
+    [pendingAvatars],
+  );
+
+  const tabAvatars = useMemo(
+    () => (taskTab === "pending" ? pendingAvatars : doneAvatars),
+    [doneAvatars, pendingAvatars, taskTab],
+  );
+
+  const filteredAvatars = useMemo(
+    () =>
+      tabAvatars.filter((avatar) => {
+        if (categoryFilter === "all") {
+          return true;
+        }
+
+        return avatar.status === "done" || avatar.status === "processing" || avatar.status === "approved";
+      }),
+    [categoryFilter, tabAvatars],
   );
 
   useEffect(() => {
     if (filteredAvatars.length === 0) {
       setSelectedAvatarId(null);
       setSelectedAvatarDetail(null);
+      setPreviewActionType(null);
       return;
     }
 
@@ -210,11 +523,12 @@ export default function Customization() {
   useEffect(() => {
     if (!selectedAvatarId) {
       setSelectedAvatarDetail(null);
+      setPreviewActionType(null);
       return;
     }
 
     void loadAvatarDetail(selectedAvatarId);
-  }, [selectedAvatarId]);
+  }, [demoAvatarDetails, isDemoMode, selectedAvatarId]);
 
   const selectedAvatarSummary = useMemo(
     () => avatars.find((avatar) => avatar.id === selectedAvatarId) ?? null,
@@ -226,11 +540,26 @@ export default function Customization() {
     [selectedAvatarDetail?.actions],
   );
 
-  const completedActionCount = selectedAvatarDetail?.actions.length ?? 0;
+  const selectedActions = selectedAvatarDetail?.actions ?? [];
+  const totalActionCount = BASIC_ACTIONS.length + FUN_ACTIONS.length;
+  const uploadedProgress = getCategoryProgress(selectedActions, "all");
+  const basicProgress = getCategoryProgress(selectedActions, "basic");
+  const funProgress = getCategoryProgress(selectedActions, "fun");
   const canEditActions = selectedAvatarDetail?.status === "approved" || selectedAvatarDetail?.status === "processing";
-  const canSync = !!selectedAvatarDetail && completedActionCount > 0 && selectedAvatarDetail.status !== "done";
+  const canSync = !!selectedAvatarDetail && uploadedProgress.completed > 0 && selectedAvatarDetail.status !== "done";
 
-  const refreshCurrentAvatar = async (avatarId: string) => {
+  const previewAction = previewActionType ? actionMap[previewActionType] : undefined;
+  const previewImageUrl = previewAction?.imageUrl ?? selectedAvatarDetail?.sourceImageUrl ?? selectedAvatarSummary?.sourceImageUrl ?? "";
+
+  const refreshCurrentAvatar = async (avatarId: string, nextDemoDetails?: CustomizationAvatarDetail[]) => {
+    if (isDemoMode) {
+      const currentDemoDetails = nextDemoDetails ?? demoAvatarDetails;
+      const nextDetail = currentDemoDetails.find((avatar) => avatar.id === avatarId) ?? null;
+      setAvatars(currentDemoDetails.map(toCustomizationAvatarSummary));
+      setSelectedAvatarDetail(nextDetail);
+      return;
+    }
+
     await Promise.all([loadAvatars(), loadAvatarDetail(avatarId, { keepLoading: true })]);
   };
 
@@ -260,6 +589,43 @@ export default function Customization() {
     setSubmittingAction(true);
 
     try {
+      if (isDemoMode) {
+        const nextDemoDetails: CustomizationAvatarDetail[] = demoAvatarDetails.map((avatar) => {
+          if (avatar.id !== selectedAvatarDetail.id) {
+            return avatar;
+          }
+
+          const existingAction = avatar.actions.find((action) => action.actionType === uploadActionType);
+          const nextAction = existingAction
+            ? {
+                ...existingAction,
+                imageUrl,
+              }
+            : {
+                id: `mock-custom-action-${Date.now()}`,
+                petAvatarId: avatar.id,
+                actionType: uploadActionType,
+                imageUrl,
+                sortOrder: avatar.actions.length,
+              };
+
+          return {
+            ...avatar,
+            status: avatar.status === "approved" ? ("processing" as const) : avatar.status,
+            actions: existingAction
+              ? avatar.actions.map((action) => (action.actionType === uploadActionType ? nextAction : action))
+              : [...avatar.actions, nextAction],
+          };
+        });
+
+        setDemoAvatarDetails(nextDemoDetails);
+        messageApi.success("演示动作素材已上传");
+        handleCloseUploadModal();
+        await refreshCurrentAvatar(selectedAvatarDetail.id, nextDemoDetails);
+        setPreviewActionType(uploadActionType);
+        return;
+      }
+
       await api.createAvatarAction(selectedAvatarDetail.id, {
         actionType: uploadActionType,
         imageUrl,
@@ -267,6 +633,7 @@ export default function Customization() {
       messageApi.success("动作素材已上传");
       handleCloseUploadModal();
       await refreshCurrentAvatar(selectedAvatarDetail.id);
+      setPreviewActionType(uploadActionType);
     } catch (error) {
       messageApi.error(error instanceof Error ? error.message : "动作素材上传失败");
     } finally {
@@ -282,6 +649,34 @@ export default function Customization() {
     setDeletingActionId(action.id);
 
     try {
+      if (isDemoMode) {
+        const nextDemoDetails: CustomizationAvatarDetail[] = demoAvatarDetails.map((avatar) => {
+          if (avatar.id !== selectedAvatarDetail.id) {
+            return avatar;
+          }
+
+          const nextActions = avatar.actions.filter((item) => item.id !== action.id);
+          return {
+            ...avatar,
+            status: nextActions.length === 0 && avatar.status === "processing" ? ("approved" as const) : avatar.status,
+            actions: nextActions,
+          };
+        });
+
+        setDemoAvatarDetails(nextDemoDetails);
+        messageApi.success("演示动作素材已删除");
+        await refreshCurrentAvatar(selectedAvatarDetail.id, nextDemoDetails);
+        setPreviewActionType((current) => {
+          if (current !== action.actionType) {
+            return current;
+          }
+
+          const nextAvatar = nextDemoDetails.find((avatar) => avatar.id === selectedAvatarDetail.id);
+          return getDefaultPreviewActionType(nextAvatar?.actions ?? []);
+        });
+        return;
+      }
+
       await api.deleteAvatarAction(selectedAvatarDetail.id, action.id);
       messageApi.success("动作素材已删除");
       await refreshCurrentAvatar(selectedAvatarDetail.id);
@@ -300,8 +695,24 @@ export default function Customization() {
     setSyncing(true);
 
     try {
+      if (isDemoMode) {
+        const nextDemoDetails: CustomizationAvatarDetail[] = demoAvatarDetails.map((avatar) =>
+          avatar.id === selectedAvatarDetail.id
+            ? {
+                ...avatar,
+                status: "done" as const,
+              }
+            : avatar,
+        );
+
+        setDemoAvatarDetails(nextDemoDetails);
+        messageApi.success("演示任务已同步到手机端");
+        await refreshCurrentAvatar(selectedAvatarDetail.id, nextDemoDetails);
+        return;
+      }
+
       await api.syncAvatar(selectedAvatarDetail.id);
-      messageApi.success("已同步到用户端");
+      messageApi.success("已同步到手机端");
       await refreshCurrentAvatar(selectedAvatarDetail.id);
     } catch (error) {
       messageApi.error(error instanceof Error ? error.message : "同步失败");
@@ -310,281 +721,355 @@ export default function Customization() {
     }
   };
 
-  const renderActionGrid = (title: string, actions: readonly ActionType[]) => (
-    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-      <div style={{ fontSize: 16, fontWeight: 600 }}>{title}</div>
-      <Row gutter={[16, 16]}>
+  const renderCategoryStatus = (avatar: CustomizationAvatar) => {
+    const avatarActions = selectedAvatarDetail?.id === avatar.id ? selectedAvatarDetail.actions : [];
+
+    if (avatarActions.length === 0) {
+      const meta = getStatusMetaForAvatarStatus(avatar.status as CustomizationStatus);
+
+      if (categoryFilter === "basic") {
+        return <Tag color={meta.color}>{`基础动作 · ${meta.label}`}</Tag>;
+      }
+
+      if (categoryFilter === "fun") {
+        return <Tag color={meta.color}>{`个性化动作 · ${meta.label}`}</Tag>;
+      }
+
+      return (
+        <Space size={[6, 6]} wrap>
+          <Tag color={meta.color}>{`基础动作 · ${meta.label}`}</Tag>
+          <Tag color={meta.color}>{`个性化动作 · ${meta.label}`}</Tag>
+        </Space>
+      );
+    }
+
+    if (categoryFilter === "basic") {
+      const meta = getCategoryStatusTag(getCategoryProgress(avatarActions, "basic"));
+      return <Tag color={meta.color}>{`基础动作 · ${meta.label}`}</Tag>;
+    }
+
+    if (categoryFilter === "fun") {
+      const meta = getCategoryStatusTag(getCategoryProgress(avatarActions, "fun"));
+      return <Tag color={meta.color}>{`个性化动作 · ${meta.label}`}</Tag>;
+    }
+
+    const basicMeta = getCategoryStatusTag(getCategoryProgress(avatarActions, "basic"));
+    const funMeta = getCategoryStatusTag(getCategoryProgress(avatarActions, "fun"));
+
+    return (
+      <Space size={[6, 6]} wrap>
+        <Tag color={basicMeta.color}>{`基础动作 · ${basicMeta.label}`}</Tag>
+        <Tag color={funMeta.color}>{`个性化动作 · ${funMeta.label}`}</Tag>
+      </Space>
+    );
+  };
+
+  const renderActionSection = (title: string, actions: readonly ActionType[]) => (
+    <Card
+      title={title}
+      styles={{ body: { padding: 16 } }}
+    >
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+          gap: 12,
+        }}
+      >
         {actions.map((actionType) => {
           const action = actionMap[actionType];
           const isDeleting = deletingActionId === action?.id;
+          const isSelected = previewActionType === actionType;
 
           return (
-            <Col key={actionType} xs={12} sm={8} xl={6} xxl={4}>
-              <Badge
-                count={action ? "✓" : 0}
-                showZero={false}
-                offset={[-10, 10]}
-                style={{ backgroundColor: "#52c41a", boxShadow: "none" }}
+            <Card
+              key={actionType}
+              hoverable
+              onClick={() => setPreviewActionType(actionType)}
+              style={{
+                borderColor: isSelected ? "#1677ff" : undefined,
+                boxShadow: isSelected ? "0 0 0 2px rgba(22,119,255,0.12)" : undefined,
+              }}
+              styles={{
+                body: {
+                  padding: 12,
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 8,
+                },
+              }}
+            >
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
+                <Text strong style={{ fontSize: 13 }}>
+                  {ACTION_LABELS[actionType] ?? actionType}
+                </Text>
+                {action ? <CheckOutlined style={{ color: "#52c41a" }} /> : null}
+              </div>
+
+              <div
+                style={{
+                  width: "100%",
+                  aspectRatio: "1 / 1",
+                  borderRadius: 10,
+                  overflow: "hidden",
+                  background: "#f5f5f5",
+                }}
               >
-                <Card
-                  size="small"
-                  styles={{
-                    body: {
-                      minHeight: 120,
-                      height: 120,
-                      padding: 12,
+                {action ? (
+                  <Image
+                    src={action.imageUrl}
+                    alt={ACTION_LABELS[actionType] ?? actionType}
+                    width="100%"
+                    height="100%"
+                    preview={false}
+                    style={{ objectFit: "cover" }}
+                  />
+                ) : (
+                  <div
+                    style={{
+                      height: "100%",
                       display: "flex",
-                      flexDirection: "column",
-                      justifyContent: "space-between",
-                    },
+                      alignItems: "center",
+                      justifyContent: "center",
+                      color: "#bfbfbf",
+                      fontSize: 12,
+                    }}
+                  >
+                    暂未上传
+                  </div>
+                )}
+              </div>
+
+              <Space direction="vertical" size={6} style={{ width: "100%" }}>
+                <Button
+                  type={action ? "default" : "primary"}
+                  size="small"
+                  icon={<UploadOutlined />}
+                  disabled={!canEditActions}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleOpenUploadModal(actionType);
                   }}
                 >
-                  {action ? (
-                    <>
-                      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
-                        <div
-                          style={{
-                            fontSize: 13,
-                            fontWeight: 600,
-                            color: "#262626",
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                          }}
-                        >
-                          {ACTION_LABELS[actionType] ?? actionType}
-                        </div>
-                        <CheckOutlined style={{ color: "#52c41a" }} />
-                      </div>
-                      <Image
-                        src={action.imageUrl}
-                        alt={ACTION_LABELS[actionType] ?? actionType}
-                        width="100%"
-                        height={58}
-                        style={{ objectFit: "cover", borderRadius: 8 }}
-                      />
-                      <Button
-                        danger
-                        size="small"
-                        icon={<DeleteOutlined />}
-                        disabled={!canEditActions}
-                        loading={isDeleting}
-                        onClick={() => void handleDeleteAction(action)}
-                      >
-                        删除
-                      </Button>
-                    </>
-                  ) : (
-                    <>
-                      <div
-                        style={{
-                          minHeight: 44,
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          textAlign: "center",
-                          fontSize: 14,
-                          fontWeight: 600,
-                          color: "#262626",
-                        }}
-                      >
-                        {ACTION_LABELS[actionType] ?? actionType}
-                      </div>
-                      <div
-                        style={{
-                          flex: 1,
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          color: "#8c8c8c",
-                          fontSize: 12,
-                        }}
-                      >
-                        暂未上传
-                      </div>
-                      <Button
-                        type="primary"
-                        size="small"
-                        icon={<UploadOutlined />}
-                        disabled={!canEditActions}
-                        onClick={() => handleOpenUploadModal(actionType)}
-                      >
-                        上传
-                      </Button>
-                    </>
-                  )}
-                </Card>
-              </Badge>
-            </Col>
+                  {action ? "替换素材" : "上传素材"}
+                </Button>
+
+                {action ? (
+                  <Button
+                    danger
+                    size="small"
+                    icon={<DeleteOutlined />}
+                    disabled={!canEditActions}
+                    loading={isDeleting}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      void handleDeleteAction(action);
+                    }}
+                  >
+                    删除
+                  </Button>
+                ) : null}
+              </Space>
+            </Card>
           );
         })}
-      </Row>
-    </div>
+      </div>
+    </Card>
   );
 
   return (
     <>
       {contextHolder}
       <Spin spinning={loading} size="large">
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-          <Row gutter={[16, 16]}>
-            <Col xs={24} md={12}>
-              <Card>
-                <Statistic title="累计定制总量" value={totalDoneCount} valueStyle={{ color: "#52c41a" }} />
-              </Card>
-            </Col>
-            <Col xs={24} md={12}>
-              <Card>
-                <Statistic title="今日新增待定制数" value={todayNewApprovedCount} valueStyle={{ color: "#1677ff" }} />
-              </Card>
-            </Col>
-          </Row>
+        <div style={{ display: "grid", gridTemplateColumns: "360px minmax(0, 1fr)", gap: 16, alignItems: "start" }}>
+          <Card styles={{ body: { padding: 16 } }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+              {isDemoMode ? (
+                <Tag color="gold" style={{ width: "fit-content", marginInlineEnd: 0 }}>
+                  演示数据
+                </Tag>
+              ) : null}
 
-          <Row gutter={[16, 16]} align="stretch">
-            <Col xs={24} lg={8}>
-              <Card
-                title="任务列表"
-                extra={
-                  <Select
-                    value={filter}
-                    onChange={(value) => setFilter(value)}
-                    options={filterOptions}
-                    style={{ width: 160 }}
-                  />
-                }
-                styles={{ body: { padding: 16 } }}
-              >
-                {filteredAvatars.length > 0 ? (
-                  <div style={{ display: "flex", flexDirection: "column", gap: 12, maxHeight: "calc(100vh - 280px)", overflowY: "auto", paddingRight: 4 }}>
-                    {filteredAvatars.map((avatar) => {
-                      const status = statusMeta[avatar.status as CustomizationStatus];
-                      const isSelected = avatar.id === selectedAvatarId;
+              <div style={{ display: "flex", gap: 8 }}>
+                <Button
+                  type={taskTab === "pending" ? "primary" : "default"}
+                  onClick={() => setTaskTab("pending")}
+                  style={{ flex: 1, height: 44 }}
+                >
+                  <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                    <span>待定制</span>
+                    <span
+                      style={{
+                        minWidth: 24,
+                        height: 24,
+                        padding: "0 6px",
+                        borderRadius: 6,
+                        background: "#fa8c16",
+                        color: "#fff",
+                        fontSize: 12,
+                        lineHeight: "24px",
+                        display: "inline-block",
+                      }}
+                    >
+                      {todayNewPendingCount}
+                    </span>
+                  </span>
+                </Button>
+                <Button
+                  type={taskTab === "done" ? "primary" : "default"}
+                  onClick={() => setTaskTab("done")}
+                  style={{ flex: 1, height: 44 }}
+                >
+                  已完成
+                </Button>
+              </div>
 
-                      return (
-                        <Card
-                          key={avatar.id}
-                          hoverable
-                          onClick={() => setSelectedAvatarId(avatar.id)}
-                          style={{
-                            borderColor: isSelected ? "#1677ff" : "#f0f0f0",
-                            boxShadow: isSelected ? "0 0 0 2px rgba(22,119,255,0.12)" : "none",
-                            cursor: "pointer",
-                          }}
-                          styles={{ body: { padding: 16 } }}
-                        >
-                          <div style={{ display: "flex", gap: 12 }}>
-                            <Image
-                              src={avatar.sourceImageUrl}
-                              alt={avatar.pet?.name ?? "宠物原图"}
-                              width={64}
-                              height={64}
-                              preview={false}
-                              style={{ objectFit: "cover", borderRadius: 8 }}
-                            />
-                            <div style={{ minWidth: 0, flex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
-                              <div
-                                style={{
-                                  fontSize: 16,
-                                  fontWeight: 600,
-                                  color: "#262626",
-                                  overflow: "hidden",
-                                  textOverflow: "ellipsis",
-                                  whiteSpace: "nowrap",
-                                }}
-                              >
-                                {avatar.user?.nickname ?? "未知用户"}
-                              </div>
-                              <div
-                                style={{
-                                  fontSize: 14,
-                                  color: "#595959",
-                                  overflow: "hidden",
-                                  textOverflow: "ellipsis",
-                                  whiteSpace: "nowrap",
-                                }}
-                              >
-                                {avatar.pet?.name ?? "未命名宠物"}
-                              </div>
-                              <div>
-                                <Tag color={status?.color}>{status?.label ?? avatar.status}</Tag>
-                              </div>
+              <Segmented<CategoryFilter>
+                block
+                value={categoryFilter}
+                options={categoryOptions}
+                onChange={(value) => setCategoryFilter(value)}
+              />
+
+              {filteredAvatars.length > 0 ? (
+                <div style={{ display: "flex", flexDirection: "column", gap: 12, maxHeight: "calc(100vh - 220px)", overflowY: "auto", paddingRight: 4 }}>
+                  {filteredAvatars.map((avatar) => {
+                    const isSelected = avatar.id === selectedAvatarId;
+
+                    return (
+                      <Card
+                        key={avatar.id}
+                        hoverable
+                        onClick={() => setSelectedAvatarId(avatar.id)}
+                        style={{
+                          borderColor: isSelected ? "#1677ff" : "#f0f0f0",
+                          boxShadow: isSelected ? "0 0 0 2px rgba(22,119,255,0.12)" : "none",
+                          cursor: "pointer",
+                        }}
+                        styles={{ body: { padding: 12 } }}
+                      >
+                        <div style={{ display: "flex", gap: 12 }}>
+                          <Image
+                            src={avatar.sourceImageUrl}
+                            alt={avatar.pet?.name ?? "宠物头像"}
+                            width={64}
+                            height={64}
+                            preview={false}
+                            style={{ objectFit: "cover", borderRadius: 10, flexShrink: 0 }}
+                          />
+
+                          <div style={{ minWidth: 0, flex: 1 }}>
+                            <div style={{ display: "flex", justifyContent: "space-between", gap: 8, marginBottom: 6 }}>
+                              <Text strong style={{ fontSize: 15 }}>
+                                {avatar.user?.nickname ?? "未知微信用户"}
+                              </Text>
+                              {renderCategoryStatus(avatar)}
+                            </div>
+
+                            <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                              <Text style={{ fontSize: 13 }}>{`宠物姓名：${avatar.pet?.name ?? "未命名宠物"}`}</Text>
+                              <Text type="secondary" style={{ fontSize: 12 }}>
+                                {`宠物品种：${avatar.pet?.breed ?? "-"}`}
+                              </Text>
+                              <Text type="secondary" style={{ fontSize: 12 }}>
+                                {`宠物年龄：${getAgeLabel(avatar.pet?.birthday)}`}
+                              </Text>
+                              <Text type="secondary" style={{ fontSize: 12 }}>
+                                {`宠物公母：${getGenderLabel(avatar.pet?.gender)}`}
+                              </Text>
                             </div>
                           </div>
-                        </Card>
-                      );
-                    })}
-                  </div>
-                ) : (
-                  <Empty description="暂无定制任务" image={Empty.PRESENTED_IMAGE_SIMPLE} />
-                )}
-              </Card>
-            </Col>
-
-            <Col xs={24} lg={16}>
-              {!selectedAvatarId || !selectedAvatarSummary ? (
-                <Card style={{ minHeight: 520 }}>
-                  <Empty description="请选择左侧任务" image={Empty.PRESENTED_IMAGE_SIMPLE} />
-                </Card>
-              ) : (
-                <Spin spinning={detailLoading}>
-                  <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-                    <Card title="工作区" styles={{ body: { padding: 16 } }}>
-                      <div style={{ display: "flex", gap: 16, alignItems: "center", flexWrap: "wrap" }}>
-                        <Image
-                          src={selectedAvatarDetail?.sourceImageUrl ?? selectedAvatarSummary.sourceImageUrl}
-                          alt={selectedAvatarDetail?.pet?.name ?? selectedAvatarSummary.pet?.name ?? "宠物原图"}
-                          width={96}
-                          height={96}
-                          preview={false}
-                          style={{ objectFit: "cover", borderRadius: 12 }}
-                        />
-                        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                          <div style={{ fontSize: 22, fontWeight: 700, color: "#262626" }}>
-                            {selectedAvatarDetail?.pet?.name ?? selectedAvatarSummary.pet?.name ?? "未命名宠物"}
-                          </div>
-                          <div style={{ fontSize: 14, color: "#595959" }}>
-                            类型：{getSpeciesLabel(selectedAvatarDetail?.pet?.species ?? selectedAvatarSummary.pet?.species)}
-                          </div>
-                          <div style={{ fontSize: 14, color: "#595959" }}>
-                            所属用户：{selectedAvatarDetail?.user?.nickname ?? selectedAvatarSummary.user?.nickname ?? "未知用户"}
-                          </div>
-                          <div>
-                            <Tag color={statusMeta[(selectedAvatarDetail?.status ?? selectedAvatarSummary.status) as CustomizationStatus]?.color}>
-                              {statusMeta[(selectedAvatarDetail?.status ?? selectedAvatarSummary.status) as CustomizationStatus]?.label ??
-                                (selectedAvatarDetail?.status ?? selectedAvatarSummary.status)}
-                            </Tag>
-                            <Tag color="default">{completedActionCount}/14 已上传</Tag>
-                          </div>
                         </div>
-                      </div>
-                    </Card>
-
-                    <Card styles={{ body: { padding: 16 } }}>
-                      <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
-                        {renderActionGrid("基础动作", BASIC_ACTIONS)}
-                        {renderActionGrid("趣味动作", FUN_ACTIONS)}
-                      </div>
-                    </Card>
-
-                    <Card styles={{ body: { padding: 16 } }}>
-                      <div style={{ display: "flex", justifyContent: "flex-end" }}>
-                        <Button
-                          type="primary"
-                          size="large"
-                          icon={<SyncOutlined />}
-                          disabled={!canSync}
-                          loading={syncing}
-                          onClick={() => void handleSyncAvatar()}
-                        >
-                          {selectedAvatarDetail?.status === "done" ? "已同步" : "一键同步"}
-                        </Button>
-                      </div>
-                    </Card>
-                  </div>
-                </Spin>
+                      </Card>
+                    );
+                  })}
+                </div>
+              ) : (
+                <Empty description="暂无定制任务" image={Empty.PRESENTED_IMAGE_SIMPLE} />
               )}
-            </Col>
-          </Row>
+            </div>
+          </Card>
+
+          {!selectedAvatarId || !selectedAvatarSummary ? (
+            <Card style={{ minHeight: 640 }}>
+              <Empty description="请选择左侧用户查看定制信息" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+            </Card>
+          ) : (
+            <Spin spinning={detailLoading}>
+              <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+                <Card styles={{ body: { padding: 16 } }}>
+                  <div style={{ display: "flex", gap: 16, justifyContent: "space-between", alignItems: "flex-start", flexWrap: "wrap" }}>
+                    <div style={{ display: "flex", gap: 16, flex: 1, minWidth: 0 }}>
+                      <div
+                        style={{
+                          width: 128,
+                          height: 128,
+                          borderRadius: 14,
+                          overflow: "hidden",
+                          background: "#f5f5f5",
+                          flexShrink: 0,
+                        }}
+                      >
+                        {previewImageUrl ? (
+                          <Image
+                            src={previewImageUrl}
+                            alt={selectedAvatarDetail?.pet?.name ?? selectedAvatarSummary.pet?.name ?? "预览图"}
+                            width={128}
+                            height={128}
+                            preview={false}
+                            style={{ objectFit: "cover" }}
+                          />
+                        ) : null}
+                      </div>
+
+                      <div style={{ minWidth: 0, flex: 1, display: "flex", flexDirection: "column", gap: 6 }}>
+                        <Title level={4} style={{ margin: 0 }}>
+                          {selectedAvatarDetail?.user?.nickname ?? selectedAvatarSummary.user?.nickname ?? "未知微信用户"}
+                        </Title>
+                        <Text>{`宠物名称：${selectedAvatarDetail?.pet?.name ?? selectedAvatarSummary.pet?.name ?? "未命名宠物"}`}</Text>
+                        <Text>{`类别：${getSpeciesLabel(selectedAvatarDetail?.pet?.species ?? selectedAvatarSummary.pet?.species)}`}</Text>
+                        <Text>{`年龄：${getAgeLabel(selectedAvatarDetail?.pet?.birthday ?? selectedAvatarSummary.pet?.birthday)}`}</Text>
+                        <Text>{`公母：${getGenderLabel(selectedAvatarDetail?.pet?.gender ?? selectedAvatarSummary.pet?.gender)}`}</Text>
+                      </div>
+                    </div>
+
+                    <Button
+                      type="primary"
+                      size="large"
+                      icon={<SyncOutlined />}
+                      disabled={!canSync}
+                      loading={syncing}
+                      style={{ background: "#52c41a", borderColor: "#52c41a" }}
+                      onClick={() => void handleSyncAvatar()}
+                    >
+                      {selectedAvatarDetail?.status === "done" ? "已同步到手机端" : "一键同步到手机端"}
+                    </Button>
+                  </div>
+
+                  <div style={{ display: "flex", flexDirection: "column", gap: 16, marginTop: 20 }}>
+                    <div>
+                      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 6 }}>
+                        <Text strong>上传进度</Text>
+                        <Text type="secondary">{`${uploadedProgress.completed}/${totalActionCount}`}</Text>
+                      </div>
+                      <Progress percent={Math.round((uploadedProgress.completed / totalActionCount) * 100)} showInfo={false} strokeColor="#1677ff" />
+                    </div>
+
+                    <div>
+                      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 6 }}>
+                        <Text strong>动作完成进度</Text>
+                        <Text type="secondary">{`${uploadedProgress.completed}/${totalActionCount} 已完成`}</Text>
+                      </div>
+                      <Progress percent={Math.round((uploadedProgress.completed / totalActionCount) * 100)} showInfo={false} strokeColor="#52c41a" />
+                    </div>
+                  </div>
+                </Card>
+
+                {renderActionSection("基础动作", BASIC_ACTIONS)}
+                {renderActionSection("个性化动作", FUN_ACTIONS)}
+              </div>
+            </Spin>
+          )}
         </div>
       </Spin>
 

--- a/packages/admin/src/pages/Devices.tsx
+++ b/packages/admin/src/pages/Devices.tsx
@@ -1,16 +1,34 @@
-import { useEffect, useState } from "react";
-import type { TableProps, TabsProps } from "antd";
-import { Button, Col, Descriptions, Drawer, Row, Select, Space, Spin, Table, Tabs, Tag, message } from "antd";
-import { ReloadOutlined } from "@ant-design/icons";
+import { useEffect, useMemo, useState } from "react";
+import type { TableProps } from "antd";
+import {
+  Divider,
+  Button,
+  Card,
+  Col,
+  Input,
+  Progress,
+  Row,
+  Space,
+  Spin,
+  Table,
+  Tag,
+  Typography,
+  message,
+} from "antd";
+import { ArrowLeftOutlined, CaretDownFilled, SearchOutlined } from "@ant-design/icons";
 import dayjs from "dayjs";
 import { api } from "../api/client";
 
-type DeviceTabKey = "collar" | "desktop";
-type OnlineStatusFilter = "all" | "online" | "offline";
-type BoundStatusFilter = "all" | "bound" | "unbound";
-type SpeciesFilter = "all" | "cat" | "dog";
-type SortField = "createdAt" | "lastOnlineAt";
-type SortOrder = "asc" | "desc";
+const { Text, Title } = Typography;
+
+type DeviceType = "collar" | "desktop";
+type DeviceModelFilter = "all" | DeviceType;
+type DeviceStatusFilter = "all" | "online" | "offline" | "pairing";
+type DeviceBoundFilter = "all" | "bound" | "unbound";
+type DeviceImageFilter = "all" | "uploaded" | "not_uploaded";
+type PetSpeciesValue = "cat" | "dog" | "other";
+type SpeciesFilter = "all" | PetSpeciesValue;
+type CreatedSortOrder = "desc" | "asc";
 
 interface BaseDevice {
   id: string;
@@ -30,82 +48,106 @@ interface CollarDevice extends BaseDevice {
   battery: number | null;
   signal: number | null;
   petName: string | null;
+  petSpecies: string | null;
+  hasUploadedImage: boolean;
 }
 
-interface DesktopDevice extends BaseDevice {}
 interface DesktopDevice extends BaseDevice {
   bindingPetNames: string[];
+  bindingPetSpeciesList: string[];
   activeBindingCount: number;
-}
-
-interface CollarFilters {
-  status: OnlineStatusFilter;
-  bound: BoundStatusFilter;
-  species: SpeciesFilter;
-  sort: SortField;
-  order: SortOrder;
-}
-
-interface DesktopFilters {
-  status: OnlineStatusFilter;
-  bound: BoundStatusFilter;
-  sort: SortField;
-  order: SortOrder;
+  hasUploadedImage: boolean;
 }
 
 type SelectedDevice =
   | { type: "collar"; record: CollarDevice }
   | { type: "desktop"; record: DesktopDevice };
 
+type DeviceListRecord = {
+  id: string;
+  type: DeviceType;
+  modelLabel: string;
+  ownerNickname: string | null;
+  deviceName: string | null;
+  searchableText: string;
+  petImageStatus: DeviceImageFilter;
+  isBound: boolean;
+  bindingStatusLabel: string;
+  petBindingText: string;
+  petSpecies: PetSpeciesValue;
+  petSpeciesLabel: string;
+  status: string;
+  createdAt: string;
+  raw: CollarDevice | DesktopDevice;
+};
+
+type SelectedDeviceSummary = {
+  modelLabel: string;
+  petImageStatus: "uploaded" | "not_uploaded";
+  isBound: boolean;
+  petSpecies: PetSpeciesValue;
+  petBindingText: string;
+};
+
+const deviceModelLabels: Record<DeviceType, string> = {
+  desktop: "桌面宠物1.0",
+  collar: "宠物项圈1.0",
+};
+
 const statusColors: Record<string, string> = {
   online: "green",
   offline: "default",
-  pairing: "blue",
+  pairing: "orange",
 };
 
 const statusLabels: Record<string, string> = {
   online: "在线",
   offline: "离线",
-  pairing: "配对中",
+  pairing: "连接中断",
 };
 
-const statusOptions = [
-  { value: "all", label: "全部" },
-  { value: "online", label: "在线" },
-  { value: "offline", label: "离线" },
-] satisfies { value: OnlineStatusFilter; label: string }[];
+const speciesLabels: Record<PetSpeciesValue, string> = {
+  cat: "猫",
+  dog: "狗",
+  other: "其他",
+};
+
+const modelOptions = [
+  { value: "all", label: "全部型号" },
+  { value: "desktop", label: "桌面宠物1.0" },
+  { value: "collar", label: "宠物项圈1.0" },
+] satisfies { value: DeviceModelFilter; label: string }[];
+
+const imageOptions = [
+  { value: "all", label: "全部图像状态" },
+  { value: "uploaded", label: "已上传" },
+  { value: "not_uploaded", label: "未上传" },
+] satisfies { value: DeviceImageFilter; label: string }[];
 
 const boundOptions = [
-  { value: "all", label: "全部" },
-  { value: "bound", label: "已绑定" },
-  { value: "unbound", label: "未绑定" },
-] satisfies { value: BoundStatusFilter; label: string }[];
+  { value: "all", label: "全部绑定状态" },
+  { value: "bound", label: "已绑定宠物" },
+  { value: "unbound", label: "未绑定宠物" },
+] satisfies { value: DeviceBoundFilter; label: string }[];
 
 const speciesOptions = [
-  { value: "all", label: "全部" },
+  { value: "all", label: "全部宠物类型" },
   { value: "cat", label: "猫" },
   { value: "dog", label: "狗" },
+  { value: "other", label: "其他" },
 ] satisfies { value: SpeciesFilter; label: string }[];
 
+const statusOptions = [
+  { value: "all", label: "全部设备状态" },
+  { value: "pairing", label: "连接中断" },
+  { value: "online", label: "在线" },
+  { value: "offline", label: "离线" },
+] satisfies { value: DeviceStatusFilter; label: string }[];
+
 const sortOptions = [
-  { value: "createdAt", label: "注册时间" },
-  { value: "lastOnlineAt", label: "最后在线时间" },
-] satisfies { value: SortField; label: string }[];
-
-const defaultCollarFilters: CollarFilters = {
-  status: "all",
-  bound: "all",
-  species: "all",
-  sort: "createdAt",
-  order: "desc",
-};
-
-const defaultDesktopFilters: DesktopFilters = {
-  status: "all",
-  bound: "all",
-  sort: "createdAt",
-  order: "desc",
-};
+  { value: "desc", label: "注册时间：倒序" },
+  { value: "asc", label: "注册时间：顺序" },
+] satisfies { value: CreatedSortOrder; label: string }[];
 
 function formatTime(value: string | null | undefined) {
   return value ? dayjs(value).format("YYYY-MM-DD HH:mm") : "-";
@@ -115,98 +157,208 @@ function renderStatus(value: string) {
   return <Tag color={statusColors[value] ?? "default"}>{statusLabels[value] ?? value}</Tag>;
 }
 
-function renderBoundUser(value: string | null) {
-  return value ?? <Tag color="orange">未绑定</Tag>;
+function renderImageStatus(value: DeviceImageFilter) {
+  if (value === "uploaded") {
+    return <Tag color="green">已上传</Tag>;
+  }
+
+  return <Tag color="default">未上传</Tag>;
 }
 
-function renderBindingPets(names?: string[]) {
-  if (!names || names.length === 0) {
+function renderBindingStatus(isBound: boolean) {
+  return isBound ? <Tag color="green">已绑定</Tag> : <Tag color="default">未绑定</Tag>;
+}
+
+function renderSpeciesTag(value: PetSpeciesValue) {
+  const color = value === "cat" ? "purple" : value === "dog" ? "cyan" : "default";
+  return <Tag color={color}>{speciesLabels[value]}</Tag>;
+}
+
+function normalizeSpecies(value?: string | null): PetSpeciesValue {
+  if (value === "cat" || value === "dog") {
+    return value;
+  }
+
+  return "other";
+}
+
+function getDesktopSpecies(speciesList: string[] | undefined): PetSpeciesValue {
+  const uniqueSpecies = new Set((speciesList ?? []).map((item) => normalizeSpecies(item)));
+
+  if (uniqueSpecies.size === 1) {
+    return Array.from(uniqueSpecies)[0];
+  }
+
+  return "other";
+}
+
+function renderFilterTitle(label: string) {
+  return (
+    <Space size={4}>
+      <span>{label}</span>
+      <CaretDownFilled style={{ fontSize: 10, color: "#8c8c8c" }} />
+    </Space>
+  );
+}
+
+function pickSingleFilter<T extends string>(value: unknown, fallback: T): T {
+  if (Array.isArray(value) && typeof value[0] === "string") {
+    return value[0] as T;
+  }
+
+  if (typeof value === "string") {
+    return value as T;
+  }
+
+  return fallback;
+}
+
+function formatRelativeTime(value: string | null | undefined) {
+  if (!value) {
     return "-";
   }
 
-  return names.join(" / ");
+  const parsed = dayjs(value);
+  if (!parsed.isValid()) {
+    return "-";
+  }
+
+  const diffMinutes = dayjs().diff(parsed, "minute");
+  if (diffMinutes < 1) {
+    return "刚刚";
+  }
+  if (diffMinutes < 60) {
+    return `${diffMinutes}分钟前`;
+  }
+
+  const diffHours = dayjs().diff(parsed, "hour");
+  if (diffHours < 24) {
+    return `${diffHours}小时前`;
+  }
+
+  return parsed.format("YYYY-MM-DD HH:mm");
 }
 
-function buildCollarParams(filters: CollarFilters) {
-  const params: Record<string, string> = {
-    sort: filters.sort,
-    order: filters.order,
-  };
-
-  if (filters.status !== "all") {
-    params.status = filters.status;
+function getSignalLabel(signal: number | null | undefined, status: string) {
+  if (status !== "online") {
+    return "-";
   }
 
-  if (filters.bound !== "all") {
-    params.bound = filters.bound === "bound" ? "true" : "false";
+  if (signal == null) {
+    return "强";
   }
 
-  if (filters.species !== "all") {
-    params.species = filters.species;
+  if (signal >= -55) {
+    return "强";
   }
 
-  return params;
+  if (signal >= -70) {
+    return "中";
+  }
+
+  return "弱";
 }
 
-function buildDesktopParams(filters: DesktopFilters) {
-  const params: Record<string, string> = {
-    sort: filters.sort,
-    order: filters.order,
-  };
+function buildDeviceRows(collars: CollarDevice[], desktops: DesktopDevice[]): DeviceListRecord[] {
+  const collarRows: DeviceListRecord[] = collars.map((record) => {
+    const petSpecies = normalizeSpecies(record.petSpecies);
+    const isBound = !!record.petId;
+    const petBindingText = record.petName ?? "-";
 
-  if (filters.status !== "all") {
-    params.status = filters.status;
-  }
+    return {
+      id: record.id,
+      type: "collar",
+      modelLabel: deviceModelLabels.collar,
+      ownerNickname: record.ownerNickname,
+      deviceName: record.name,
+      searchableText: [
+        record.id,
+        record.name,
+        record.ownerNickname,
+        record.petName,
+        deviceModelLabels.collar,
+        record.macAddress,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase(),
+      petImageStatus: isBound && record.hasUploadedImage ? "uploaded" : "not_uploaded",
+      isBound,
+      bindingStatusLabel: isBound ? "已绑定宠物" : "未绑定宠物",
+      petBindingText,
+      petSpecies: isBound ? petSpecies : "other",
+      petSpeciesLabel: speciesLabels[isBound ? petSpecies : "other"],
+      status: record.status,
+      createdAt: record.createdAt,
+      raw: record,
+    };
+  });
 
-  if (filters.bound !== "all") {
-    params.bound = filters.bound === "bound" ? "true" : "false";
-  }
+  const desktopRows: DeviceListRecord[] = desktops.map((record) => {
+    const petSpecies = record.activeBindingCount > 0 ? getDesktopSpecies(record.bindingPetSpeciesList) : "other";
+    const isBound = record.activeBindingCount > 0;
+    const petBindingText = isBound ? record.bindingPetNames.join(" / ") : "-";
 
-  return params;
+    return {
+      id: record.id,
+      type: "desktop",
+      modelLabel: deviceModelLabels.desktop,
+      ownerNickname: record.ownerNickname,
+      deviceName: record.name,
+      searchableText: [
+        record.id,
+        record.name,
+        record.ownerNickname,
+        record.bindingPetNames.join(" "),
+        deviceModelLabels.desktop,
+        record.macAddress,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase(),
+      petImageStatus: isBound && record.hasUploadedImage ? "uploaded" : "not_uploaded",
+      isBound,
+      bindingStatusLabel: isBound ? "已绑定宠物" : "未绑定宠物",
+      petBindingText,
+      petSpecies,
+      petSpeciesLabel: speciesLabels[petSpecies],
+      status: record.status,
+      createdAt: record.createdAt,
+      raw: record,
+    };
+  });
+
+  return [...collarRows, ...desktopRows];
 }
 
 export default function DevicesPage() {
-  const [activeTab, setActiveTab] = useState<DeviceTabKey>("collar");
   const [loading, setLoading] = useState(true);
-  const [reloadToken, setReloadToken] = useState(0);
   const [collars, setCollars] = useState<CollarDevice[]>([]);
   const [desktops, setDesktops] = useState<DesktopDevice[]>([]);
-  const [collarFilters, setCollarFilters] = useState<CollarFilters>(defaultCollarFilters);
-  const [desktopFilters, setDesktopFilters] = useState<DesktopFilters>(defaultDesktopFilters);
+  const [keyword, setKeyword] = useState("");
+  const [modelFilter, setModelFilter] = useState<DeviceModelFilter>("all");
+  const [imageFilter, setImageFilter] = useState<DeviceImageFilter>("all");
+  const [boundFilter, setBoundFilter] = useState<DeviceBoundFilter>("all");
+  const [speciesFilter, setSpeciesFilter] = useState<SpeciesFilter>("all");
+  const [statusFilter, setStatusFilter] = useState<DeviceStatusFilter>("all");
+  const [sortOrder, setSortOrder] = useState<CreatedSortOrder>("desc");
   const [selectedDevice, setSelectedDevice] = useState<SelectedDevice | null>(null);
-
-  const collarQueryKey = [
-    collarFilters.status,
-    collarFilters.bound,
-    collarFilters.species,
-    collarFilters.sort,
-    collarFilters.order,
-  ].join("|");
-
-  const desktopQueryKey = [
-    desktopFilters.status,
-    desktopFilters.bound,
-    desktopFilters.sort,
-    desktopFilters.order,
-  ].join("|");
 
   useEffect(() => {
     let cancelled = false;
 
-    async function load() {
+    async function loadDevices() {
       setLoading(true);
 
       try {
-        if (activeTab === "collar") {
-          const result = await api.getFilteredCollars(buildCollarParams(collarFilters));
-          if (!cancelled) {
-            setCollars(result.collars as CollarDevice[]);
-          }
-        } else {
-          const result = await api.getFilteredDesktops(buildDesktopParams(desktopFilters));
-          if (!cancelled) {
-            setDesktops(result.desktops as DesktopDevice[]);
-          }
+        const [collarResult, desktopResult] = await Promise.all([
+          api.getFilteredCollars({ sort: "createdAt", order: "desc" }),
+          api.getFilteredDesktops({ sort: "createdAt", order: "desc" }),
+        ]);
+
+        if (!cancelled) {
+          setCollars((collarResult.collars as CollarDevice[]) ?? []);
+          setDesktops((desktopResult.desktops as DesktopDevice[]) ?? []);
         }
       } catch (error) {
         if (!cancelled) {
@@ -219,346 +371,556 @@ export default function DevicesPage() {
       }
     }
 
-    void load();
+    void loadDevices();
 
     return () => {
       cancelled = true;
     };
-  }, [activeTab, reloadToken, activeTab === "collar" ? collarQueryKey : desktopQueryKey]);
+  }, []);
 
-  const collarColumns: TableProps<CollarDevice>["columns"] = [
+  const deviceRows = useMemo(() => buildDeviceRows(collars, desktops), [collars, desktops]);
+
+  const filteredDevices = useMemo(() => {
+    const normalizedKeyword = keyword.trim().toLowerCase();
+
+    return deviceRows
+      .filter((device) => {
+        if (normalizedKeyword && !device.searchableText.includes(normalizedKeyword)) {
+          return false;
+        }
+
+        if (modelFilter !== "all" && device.type !== modelFilter) {
+          return false;
+        }
+
+        if (imageFilter !== "all" && device.petImageStatus !== imageFilter) {
+          return false;
+        }
+
+        if (boundFilter === "bound" && !device.isBound) {
+          return false;
+        }
+
+        if (boundFilter === "unbound" && device.isBound) {
+          return false;
+        }
+
+        if (speciesFilter !== "all" && device.petSpecies !== speciesFilter) {
+          return false;
+        }
+
+        if (statusFilter !== "all" && device.status !== statusFilter) {
+          return false;
+        }
+
+        return true;
+      })
+      .sort((left, right) => {
+        const leftTime = dayjs(left.createdAt).valueOf();
+        const rightTime = dayjs(right.createdAt).valueOf();
+        return sortOrder === "asc" ? leftTime - rightTime : rightTime - leftTime;
+      });
+  }, [boundFilter, deviceRows, imageFilter, keyword, modelFilter, sortOrder, speciesFilter, statusFilter]);
+
+  const boundDeviceCount = useMemo(
+    () => filteredDevices.filter((device) => device.isBound).length,
+    [filteredDevices],
+  );
+
+  const columns: TableProps<DeviceListRecord>["columns"] = [
     {
-      title: "设备名称",
-      dataIndex: "name",
-      key: "name",
-      width: 180,
-      render: (value: string | null) => value ?? "-",
+      title: "设备ID",
+      dataIndex: "id",
+      key: "id",
+      width: 220,
+      render: (value: string, record) => (
+        <Space direction="vertical" size={2}>
+          <Text strong>{value}</Text>
+          <Text type="secondary">{record.deviceName ?? "-"}</Text>
+        </Space>
+      ),
     },
     {
-      title: "MAC 地址",
-      dataIndex: "macAddress",
+      title: "Mac地址",
+      dataIndex: "raw",
       key: "macAddress",
       width: 180,
-      render: (value: string | null) => value ?? "-",
+      render: (_value, record) => (record.raw.macAddress ?? "-"),
     },
     {
-      title: "状态",
-      dataIndex: "status",
-      key: "status",
-      width: 100,
-      render: (value: string) => renderStatus(value),
+      title: "设备型号",
+      dataIndex: "modelLabel",
+      key: "modelLabel",
+      width: 150,
+      filters: modelOptions.filter((option) => option.value !== "all").map((option) => ({ text: option.label, value: option.value })),
+      filteredValue: modelFilter === "all" ? null : [modelFilter],
+      onFilter: (value, record) => record.type === value,
+      render: (value: string) => value,
     },
     {
-      title: "电量",
-      dataIndex: "battery",
-      key: "battery",
-      width: 90,
-      render: (value: number | null) => (value == null ? "-" : `${value}%`),
-    },
-    {
-      title: "信号",
-      dataIndex: "signal",
-      key: "signal",
-      width: 100,
-      render: (value: number | null) => (value == null ? "-" : `${value} dBm`),
-    },
-    {
-      title: "绑定用户",
-      dataIndex: "ownerNickname",
-      key: "ownerNickname",
-      width: 140,
-      render: (value: string | null) => renderBoundUser(value),
-    },
-    {
-      title: "绑定宠物",
-      dataIndex: "petName",
-      key: "petName",
-      width: 140,
-      render: (value: string | null) => value ?? "-",
-    },
-    {
-      title: "最后在线时间",
-      dataIndex: "lastOnlineAt",
-      key: "lastOnlineAt",
-      width: 180,
-      render: (value: string | null) => formatTime(value),
-    },
-    {
-      title: "注册时间",
-      dataIndex: "createdAt",
-      key: "createdAt",
-      width: 180,
-      render: (value: string) => formatTime(value),
-    },
-  ];
-
-  const desktopColumns: TableProps<DesktopDevice>["columns"] = [
-    {
-      title: "设备名称",
-      dataIndex: "name",
-      key: "name",
-      width: 180,
-      render: (value: string | null) => value ?? "-",
-    },
-    {
-      title: "MAC 地址",
-      dataIndex: "macAddress",
-      key: "macAddress",
-      width: 180,
-      render: (value: string | null) => value ?? "-",
-    },
-    {
-      title: "状态",
-      dataIndex: "status",
-      key: "status",
-      width: 100,
-      render: (value: string) => renderStatus(value),
-    },
-    {
-      title: "固件版本",
-      dataIndex: "firmwareVersion",
-      key: "firmwareVersion",
+      title: renderFilterTitle("宠物头像"),
+      dataIndex: "petImageStatus",
+      key: "petImageStatus",
       width: 120,
-      render: (value: string | null) => value ?? "-",
+      filters: imageOptions.filter((option) => option.value !== "all").map((option) => ({ text: option.label, value: option.value })),
+      filteredValue: imageFilter === "all" ? null : [imageFilter],
+      onFilter: (value, record) => record.petImageStatus === value,
+      render: (value: DeviceImageFilter) => renderImageStatus(value),
     },
     {
-      title: "绑定用户",
+      title: renderFilterTitle("设备绑定"),
+      dataIndex: "isBound",
+      key: "isBound",
+      width: 120,
+      filters: [
+        { text: "已绑定", value: "bound" },
+        { text: "未绑定", value: "unbound" },
+      ],
+      filteredValue: boundFilter === "all" ? null : [boundFilter],
+      onFilter: (value, record) => (value === "bound" ? record.isBound : !record.isBound),
+      render: (value: boolean) => renderBindingStatus(value),
+    },
+    {
+      title: renderFilterTitle("宠物类型"),
+      dataIndex: "petSpecies",
+      key: "petSpecies",
+      width: 180,
+      filters: speciesOptions.filter((option) => option.value !== "all").map((option) => ({ text: option.label, value: option.value })),
+      filteredValue: speciesFilter === "all" ? null : [speciesFilter],
+      onFilter: (value, record) => record.petSpecies === value,
+      render: (value: PetSpeciesValue, record) => (
+        <Space direction="vertical" size={2}>
+          <Text>{record.petBindingText}</Text>
+          <Text type="secondary">{speciesLabels[value]}</Text>
+        </Space>
+      ),
+    },
+    {
+      title: renderFilterTitle("设备状态"),
+      dataIndex: "status",
+      key: "status",
+      width: 120,
+      filters: statusOptions.filter((option) => option.value !== "all").map((option) => ({ text: option.label, value: option.value })),
+      filteredValue: statusFilter === "all" ? null : [statusFilter],
+      onFilter: (value, record) => record.status === value,
+      render: (value: string) => renderStatus(value),
+    },
+    {
+      title: "用户信息",
       dataIndex: "ownerNickname",
       key: "ownerNickname",
       width: 140,
-      render: (value: string | null) => renderBoundUser(value),
+      render: (value: string | null) => value ?? "-",
     },
     {
-      title: "绑定宠物",
-      dataIndex: "bindingPetNames",
-      key: "bindingPetNames",
-      width: 180,
-      render: (value: string[] | undefined) => renderBindingPets(value),
-    },
-    {
-      title: "最后在线时间",
-      dataIndex: "lastOnlineAt",
-      key: "lastOnlineAt",
-      width: 180,
-      render: (value: string | null) => formatTime(value),
-    },
-    {
-      title: "注册时间",
+      title: renderFilterTitle("注册时间"),
       dataIndex: "createdAt",
       key: "createdAt",
       width: 180,
+      filters: [
+        { text: "倒序", value: "desc" },
+        { text: "顺序", value: "asc" },
+      ],
+      filteredValue: [sortOrder],
+      onFilter: () => true,
       render: (value: string) => formatTime(value),
     },
-  ];
-
-  const activeFilters = activeTab === "collar" ? collarFilters : desktopFilters;
-
-  const tabItems: TabsProps["items"] = [
     {
-      key: "collar",
-      label: "项圈",
-      children: (
-        <Table<CollarDevice>
-          dataSource={collars}
-          columns={collarColumns}
-          rowKey="id"
-          size="middle"
-          scroll={{ x: 1400 }}
-          pagination={{ pageSize: 10, showSizeChanger: false }}
-          onRow={(record) => ({
-            onClick: () => setSelectedDevice({ type: "collar", record }),
-            style: { cursor: "pointer" },
-          })}
-        />
-      ),
-    },
-    {
-      key: "desktop",
-      label: "桌面端",
-      children: (
-        <Table<DesktopDevice>
-          dataSource={desktops}
-          columns={desktopColumns}
-          rowKey="id"
-          size="middle"
-          scroll={{ x: 1200 }}
-          pagination={{ pageSize: 10, showSizeChanger: false }}
-          onRow={(record) => ({
-            onClick: () => setSelectedDevice({ type: "desktop", record }),
-            style: { cursor: "pointer" },
-          })}
-        />
+      title: "管理设备",
+      key: "actions",
+      width: 100,
+      fixed: "right",
+      render: (_value, record) => (
+        <Space size={4}>
+          <Button
+            type="link"
+            onClick={() =>
+              setSelectedDevice(
+                record.type === "collar"
+                  ? { type: "collar", record: record.raw as CollarDevice }
+                  : { type: "desktop", record: record.raw as DesktopDevice },
+              )
+            }
+          >
+            管理
+          </Button>
+        </Space>
       ),
     },
   ];
+
+  const selectedDeviceSummary = useMemo<SelectedDeviceSummary | null>(() => {
+    if (!selectedDevice) {
+      return null;
+    }
+
+    if (selectedDevice.type === "collar") {
+      const petSpecies = selectedDevice.record.petId ? normalizeSpecies(selectedDevice.record.petSpecies) : "other";
+      return {
+        modelLabel: deviceModelLabels.collar,
+        petImageStatus: selectedDevice.record.petId && selectedDevice.record.hasUploadedImage ? "uploaded" : "not_uploaded",
+        isBound: !!selectedDevice.record.petId,
+        petSpecies,
+        petBindingText: selectedDevice.record.petName ?? "-",
+      };
+    }
+
+    const petSpecies = selectedDevice.record.activeBindingCount > 0 ? getDesktopSpecies(selectedDevice.record.bindingPetSpeciesList) : "other";
+    return {
+      modelLabel: deviceModelLabels.desktop,
+      petImageStatus: selectedDevice.record.activeBindingCount > 0 && selectedDevice.record.hasUploadedImage ? "uploaded" : "not_uploaded",
+      isBound: selectedDevice.record.activeBindingCount > 0,
+      petSpecies,
+      petBindingText: selectedDevice.record.activeBindingCount > 0 ? selectedDevice.record.bindingPetNames.join(" / ") : "-",
+    };
+  }, [selectedDevice]);
+
+  const selectedDeviceTitle = useMemo(() => {
+    if (!selectedDevice || !selectedDeviceSummary) {
+      return "设备详情";
+    }
+
+    return `${selectedDevice.record.name ?? selectedDeviceSummary.modelLabel}设备详情`;
+  }, [selectedDevice, selectedDeviceSummary]);
+
+  const selectedDeviceDetail = useMemo(() => {
+    if (!selectedDevice || !selectedDeviceSummary) {
+      return null;
+    }
+
+    const counterpart =
+      selectedDevice.type === "collar"
+        ? desktops.find((desktop) => desktop.userId && desktop.userId === selectedDevice.record.userId) ?? null
+        : collars.find((collar) => collar.userId && collar.userId === selectedDevice.record.userId) ?? null;
+
+    const isCollar = selectedDevice.type === "collar";
+    const batteryPercent = isCollar ? selectedDevice.record.battery ?? 85 : 85;
+    const signalLabel = isCollar
+      ? getSignalLabel(selectedDevice.record.signal, selectedDevice.record.status)
+      : getSignalLabel(null, selectedDevice.record.status);
+    const signalColor = signalLabel === "强" ? "#16a34a" : signalLabel === "中" ? "#d97706" : "#9ca3af";
+    const customizationCompleted = selectedDeviceSummary.petImageStatus === "uploaded" ? 3 : 0;
+    const customizationTotal = 18;
+    const bindingDurationDays = Math.max(1, dayjs().diff(dayjs(selectedDevice.record.createdAt), "day"));
+
+    return {
+      batteryPercent,
+      signalLabel,
+      signalColor,
+      lastSyncLabel: formatRelativeTime(selectedDevice.record.lastOnlineAt ?? selectedDevice.record.updatedAt),
+      activeAtLabel: formatTime(selectedDevice.record.createdAt),
+      counterpart,
+      customizationCompleted,
+      customizationTotal,
+      customizationPercent: Math.round((customizationCompleted / customizationTotal) * 100),
+      bindingDurationDays,
+    };
+  }, [collars, desktops, selectedDevice, selectedDeviceSummary]);
+
+  if (selectedDevice && selectedDeviceSummary && selectedDeviceDetail) {
+    return (
+      <Space direction="vertical" size={20} style={{ display: "flex" }}>
+        <Button
+          type="link"
+          icon={<ArrowLeftOutlined />}
+          style={{ padding: 0, width: "fit-content" }}
+          onClick={() => setSelectedDevice(null)}
+        >
+          返回列表
+        </Button>
+
+        <Card styles={{ body: { padding: 24 } }}>
+          <Divider style={{ margin: "0 0 24px" }} />
+
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "center", flexWrap: "wrap", marginBottom: 28 }}>
+            <Title level={3} style={{ margin: 0 }}>
+              {selectedDeviceTitle}
+            </Title>
+
+            <Space size={16}>
+              <Button
+                type="primary"
+                disabled
+                style={{
+                  background: "#69a7ff",
+                  borderColor: "#69a7ff",
+                  minWidth: 120,
+                  height: 40,
+                  borderRadius: 12,
+                }}
+              >
+                管理员编辑
+              </Button>
+              <Button
+                danger
+                disabled
+                style={{
+                  minWidth: 120,
+                  height: 40,
+                  borderRadius: 12,
+                }}
+              >
+                永久删除
+              </Button>
+            </Space>
+          </div>
+
+          <Row gutter={[32, 20]} style={{ marginBottom: 28 }}>
+            <Col xs={24} md={12} xl={6}>
+              <Space direction="vertical" size={10}>
+                <div><Text type="secondary">设备名称</Text> <Text strong>{selectedDevice.record.name ?? "-"}</Text></div>
+                <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <Text type="secondary">电池状态</Text>
+                  <Text strong>{`${selectedDeviceDetail.batteryPercent}%`}</Text>
+                  <Progress
+                    percent={selectedDeviceDetail.batteryPercent}
+                    showInfo={false}
+                    strokeColor="#22c55e"
+                    trailColor="#e5e7eb"
+                    style={{ width: 90, marginInlineStart: 4 }}
+                  />
+                </div>
+              </Space>
+            </Col>
+            <Col xs={24} md={12} xl={6}>
+              <Space direction="vertical" size={10}>
+                <div><Text type="secondary">设备型号</Text> <Text strong>{selectedDeviceSummary.modelLabel}</Text></div>
+                <div><Text type="secondary">信号强度</Text> <Text strong style={{ color: selectedDeviceDetail.signalColor }}>{selectedDeviceDetail.signalLabel}</Text></div>
+              </Space>
+            </Col>
+            <Col xs={24} md={12} xl={6}>
+              <Space direction="vertical" size={10}>
+                <div><Text type="secondary">MAC地址</Text> <Text strong>{selectedDevice.record.macAddress ?? "-"}</Text></div>
+                <div><Text type="secondary">最后同步</Text> <Text strong>{selectedDeviceDetail.lastSyncLabel}</Text></div>
+              </Space>
+            </Col>
+            <Col xs={24} md={12} xl={6}>
+              <Space direction="vertical" size={10}>
+                <div><Text type="secondary">固件版本</Text> <Text strong>{selectedDevice.record.firmwareVersion ?? "v2.4.1"}</Text></div>
+                <div><Text type="secondary">激活时间</Text> <Text strong>{selectedDeviceDetail.activeAtLabel}</Text></div>
+              </Space>
+            </Col>
+          </Row>
+
+          <Card title={<Text strong style={{ fontSize: 16 }}>设备宠物</Text>} styles={{ body: { padding: 16 } }}>
+            <Row gutter={[16, 16]}>
+              <Col xs={24} xl={12}>
+                <Card
+                  bordered={false}
+                  style={{ background: "#f8fafc", borderRadius: 16, minHeight: 250 }}
+                  styles={{ body: { padding: 18 } }}
+                >
+                  <Space direction="vertical" size={12} style={{ width: "100%" }}>
+                    <div>
+                      <Text strong>设备宠物信息</Text>
+                      <div style={{ marginTop: 4 }}>{renderBindingStatus(selectedDeviceSummary.isBound)}</div>
+                    </div>
+
+                    <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+                      <div
+                        style={{
+                          width: 84,
+                          height: 84,
+                          borderRadius: "50%",
+                          background: "#dbe4f0",
+                          flexShrink: 0,
+                        }}
+                      />
+                      <div style={{ minWidth: 0 }}>
+                        <Title level={4} style={{ margin: 0 }}>
+                          {selectedDeviceSummary.petBindingText}
+                        </Title>
+                        <Text type="secondary">
+                          {`${speciesLabels[selectedDeviceSummary.petSpecies]} | ${selectedDevice.record.id.slice(0, 4).toUpperCase()}`}
+                        </Text>
+                      </div>
+                    </div>
+
+                    <Row gutter={[12, 12]}>
+                      <Col span={8}>
+                        <Text type="secondary">主人</Text>
+                        <div><Text strong>{selectedDevice.record.ownerNickname ?? "-"}</Text></div>
+                      </Col>
+                      <Col span={8}>
+                        <Text type="secondary">陪伴时长</Text>
+                        <div><Text strong style={{ color: "#3b82f6" }}>{`${selectedDeviceDetail.bindingDurationDays}天`}</Text></div>
+                      </Col>
+                      <Col span={8}>
+                        <Text type="secondary">宠物编号</Text>
+                        <div><Text strong>{selectedDeviceSummary.isBound ? `PET${selectedDevice.record.id.slice(-3).toUpperCase()}` : "-"}</Text></div>
+                      </Col>
+                    </Row>
+                  </Space>
+                </Card>
+              </Col>
+
+              <Col xs={24} xl={12}>
+                <Card
+                  bordered={false}
+                  style={{ background: "#effcf5", borderRadius: 16, minHeight: 250 }}
+                  styles={{ body: { padding: 18 } }}
+                >
+                  <Space direction="vertical" size={12} style={{ width: "100%" }}>
+                    <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+                      <div>
+                        <Text strong style={{ color: "#166534" }}>宠物图像定制</Text>
+                        <div style={{ marginTop: 4 }}><Text type="secondary">定制中</Text></div>
+                      </div>
+                      <Text strong style={{ color: "#166534", fontSize: 28 }}>
+                        {`${selectedDeviceDetail.customizationCompleted}/${selectedDeviceDetail.customizationTotal} 完成`}
+                      </Text>
+                    </div>
+
+                    <Space direction="vertical" size={8}>
+                      <Text style={{ color: "#166534" }}>{selectedDeviceSummary.petImageStatus === "uploaded" ? "✓ 图像已上传" : "× 图像未上传"}</Text>
+                      <Text style={{ color: "#166534" }}>{selectedDeviceSummary.petImageStatus === "uploaded" ? "✓ 图像已审核" : "× 等待图像审核"}</Text>
+                      <Text type="secondary">{`× 动态生成中 ${selectedDeviceDetail.customizationCompleted}/${selectedDeviceDetail.customizationTotal}`}</Text>
+                    </Space>
+
+                    <Progress
+                      percent={selectedDeviceDetail.customizationPercent}
+                      showInfo={false}
+                      strokeColor="#22c55e"
+                      trailColor="#dbe4f0"
+                    />
+
+                    <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                      <Text type="secondary">{`最后更新 ${formatTime(selectedDevice.record.updatedAt)}`}</Text>
+                    </div>
+                  </Space>
+                </Card>
+              </Col>
+
+              <Col xs={24} xl={12}>
+                <Card
+                  bordered={false}
+                  style={{ background: "#eef5ff", borderRadius: 16, minHeight: 220 }}
+                  styles={{ body: { padding: 18 } }}
+                >
+                  <Space direction="vertical" size={16} style={{ width: "100%" }}>
+                    <div>
+                      <Text strong style={{ color: "#1d4ed8" }}>
+                        {selectedDevice.type === "desktop" ? "桌面端与项圈绑定" : "项圈与桌面端绑定"}
+                      </Text>
+                      <div style={{ marginTop: 4 }}>{renderBindingStatus(!!selectedDeviceDetail.counterpart)}</div>
+                    </div>
+
+                    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+                      <Card bordered={false} style={{ background: "#dbeafe", width: "100%" }} styles={{ body: { padding: 16, textAlign: "center" } }}>
+                        <Text type="secondary">{selectedDevice.type === "desktop" ? "桌面端" : "项圈"}</Text>
+                        <Title level={4} style={{ margin: "8px 0 0" }}>{selectedDevice.record.name ?? selectedDeviceSummary.modelLabel}</Title>
+                      </Card>
+                      <Text style={{ fontSize: 28, color: "#0f172a" }}>⟷</Text>
+                      <Card bordered={false} style={{ background: "#dbeafe", width: "100%" }} styles={{ body: { padding: 16, textAlign: "center" } }}>
+                        <Text type="secondary">{selectedDevice.type === "desktop" ? "项圈" : "桌面端"}</Text>
+                        <Title level={4} style={{ margin: "8px 0 0" }}>
+                          {selectedDeviceDetail.counterpart?.name ?? "暂无绑定设备"}
+                        </Title>
+                      </Card>
+                    </div>
+
+                    <div style={{ textAlign: "center" }}>
+                      <Text type="secondary">{selectedDeviceDetail.counterpart ? `绑定${selectedDeviceDetail.bindingDurationDays}天` : "待建立绑定关系"}</Text>
+                    </div>
+                  </Space>
+                </Card>
+              </Col>
+
+              <Col xs={24} xl={12}>
+                <Card
+                  bordered={false}
+                  style={{ background: "#fff7ed", borderRadius: 16, minHeight: 220 }}
+                  styles={{ body: { padding: 18 } }}
+                >
+                  <Space direction="vertical" size={16} style={{ width: "100%" }}>
+                    <div>
+                      <Text strong style={{ color: "#c2410c" }}>项圈状态信息</Text>
+                      <div style={{ marginTop: 4 }}>{renderStatus(selectedDevice.record.status)}</div>
+                    </div>
+
+                    <Row gutter={[16, 16]}>
+                      <Col span={12}>
+                        <Text type="secondary">连接状态</Text>
+                        <div><Text strong style={{ color: "#16a34a" }}>{selectedDevice.record.status === "online" ? "已连接" : statusLabels[selectedDevice.record.status] ?? "-"}</Text></div>
+                      </Col>
+                      <Col span={12}>
+                        <Text type="secondary">设备型号</Text>
+                        <div><Text strong>{selectedDeviceSummary.modelLabel}</Text></div>
+                      </Col>
+                      <Col span={12}>
+                        <Text type="secondary">最近活跃</Text>
+                        <div><Text strong>{selectedDeviceDetail.lastSyncLabel}</Text></div>
+                      </Col>
+                      <Col span={12}>
+                        <Text type="secondary">激活时间</Text>
+                        <div><Text strong>{dayjs(selectedDevice.record.createdAt).format("YYYY-MM-DD")}</Text></div>
+                      </Col>
+                      <Col span={12}>
+                        <Text type="secondary">电池</Text>
+                        <div><Text strong>{`${selectedDeviceDetail.batteryPercent}%`}</Text></div>
+                      </Col>
+                      <Col span={12}>
+                        <Text type="secondary">信号</Text>
+                        <div><Text strong style={{ color: selectedDeviceDetail.signalColor }}>{selectedDeviceDetail.signalLabel}</Text></div>
+                      </Col>
+                    </Row>
+                  </Space>
+                </Card>
+              </Col>
+            </Row>
+          </Card>
+        </Card>
+      </Space>
+    );
+  }
 
   return (
     <>
-      <div style={{ marginBottom: 16 }}>
-        <h2 style={{ margin: 0 }}>设备管理</h2>
-      </div>
+      <Space direction="vertical" size={16} style={{ display: "flex" }}>
+        <div>
+          <Title level={2} style={{ margin: 0 }}>
+            设备管理
+          </Title>
+        </div>
 
-      <Row gutter={[12, 12]} align="middle" style={{ marginBottom: 16 }}>
-        <Col flex="160px">
-          <Select<OnlineStatusFilter>
-            value={activeFilters.status}
-            style={{ width: "100%" }}
-            options={statusOptions}
-            onChange={(value) => {
-              if (activeTab === "collar") {
-                setCollarFilters((prev) => ({ ...prev, status: value }));
-              } else {
-                setDesktopFilters((prev) => ({ ...prev, status: value }));
-              }
-            }}
+        <Card>
+          <Input
+            allowClear
+            value={keyword}
+            prefix={<SearchOutlined />}
+            placeholder="搜索ID设备、型号、用户..."
+            onChange={(event) => setKeyword(event.target.value)}
           />
-        </Col>
-        <Col flex="160px">
-          <Select<BoundStatusFilter>
-            value={activeFilters.bound}
-            style={{ width: "100%" }}
-            options={boundOptions}
-            onChange={(value) => {
-              if (activeTab === "collar") {
-                setCollarFilters((prev) => ({ ...prev, bound: value }));
-              } else {
-                setDesktopFilters((prev) => ({ ...prev, bound: value }));
-              }
-            }}
-          />
-        </Col>
-        {activeTab === "collar" ? (
-          <Col flex="160px">
-            <Select<SpeciesFilter>
-              value={collarFilters.species}
-              style={{ width: "100%" }}
-              options={speciesOptions}
-              onChange={(value) => setCollarFilters((prev) => ({ ...prev, species: value }))}
+        </Card>
+
+        <Card
+          title={
+            <Space split={<Text type="secondary">|</Text>}>
+              <Text strong>设备列表</Text>
+              <Text type="secondary">共 {filteredDevices.length} 台设备</Text>
+              <Text type="secondary">{boundDeviceCount} 台设备已绑定</Text>
+            </Space>
+          }
+        >
+          <Spin spinning={loading}>
+            <Table<DeviceListRecord>
+              dataSource={filteredDevices}
+              columns={columns}
+              rowKey={(record) => `${record.type}-${record.id}`}
+              scroll={{ x: 1380 }}
+              pagination={{ pageSize: 10, showSizeChanger: false }}
+              onChange={(_pagination, filters) => {
+                setModelFilter(pickSingleFilter<DeviceModelFilter>(filters.modelLabel, "all"));
+                setImageFilter(pickSingleFilter<DeviceImageFilter>(filters.petImageStatus, "all"));
+                setBoundFilter(pickSingleFilter<DeviceBoundFilter>(filters.isBound, "all"));
+                setSpeciesFilter(pickSingleFilter<SpeciesFilter>(filters.petSpecies, "all"));
+                setStatusFilter(pickSingleFilter<DeviceStatusFilter>(filters.status, "all"));
+                setSortOrder(pickSingleFilter<CreatedSortOrder>(filters.createdAt, "desc"));
+              }}
             />
-          </Col>
-        ) : null}
-        <Col flex="180px">
-          <Select<SortField>
-            value={activeFilters.sort}
-            style={{ width: "100%" }}
-            options={sortOptions}
-            onChange={(value) => {
-              if (activeTab === "collar") {
-                setCollarFilters((prev) => ({ ...prev, sort: value }));
-              } else {
-                setDesktopFilters((prev) => ({ ...prev, sort: value }));
-              }
-            }}
-          />
-        </Col>
-        <Col flex="120px">
-          <Button
-            block
-            onClick={() => {
-              if (activeTab === "collar") {
-                setCollarFilters((prev) => ({ ...prev, order: prev.order === "asc" ? "desc" : "asc" }));
-              } else {
-                setDesktopFilters((prev) => ({ ...prev, order: prev.order === "asc" ? "desc" : "asc" }));
-              }
-            }}
-          >
-            {activeFilters.order === "asc" ? "升序" : "降序"}
-          </Button>
-        </Col>
-        <Col flex="120px">
-          <Button block icon={<ReloadOutlined />} onClick={() => setReloadToken((value) => value + 1)}>
-            刷新
-          </Button>
-        </Col>
-      </Row>
-
-      <Spin spinning={loading}>
-        <Tabs
-          activeKey={activeTab}
-          items={tabItems}
-          onChange={(key) => {
-            setActiveTab(key as DeviceTabKey);
-            setSelectedDevice(null);
-          }}
-        />
-      </Spin>
-
-      <Drawer
-        title={selectedDevice?.type === "collar" ? "项圈详情" : "桌面端详情"}
-        width={480}
-        open={!!selectedDevice}
-        onClose={() => setSelectedDevice(null)}
-        extra={
-          <Button onClick={() => setSelectedDevice(null)}>
-            关闭
-          </Button>
-        }
-      >
-        {selectedDevice ? (
-          <Space direction="vertical" size={16} style={{ width: "100%" }}>
-            <Descriptions
-              bordered
-              column={1}
-              size="small"
-              items={
-                selectedDevice.type === "collar"
-                  ? [
-                      { key: "name", label: "设备名称", children: selectedDevice.record.name ?? "-" },
-                      { key: "id", label: "设备 ID", children: selectedDevice.record.id },
-                      { key: "mac", label: "MAC 地址", children: selectedDevice.record.macAddress ?? "-" },
-                      { key: "status", label: "在线状态", children: renderStatus(selectedDevice.record.status) },
-                      {
-                        key: "bound",
-                        label: "绑定状态",
-                        children: selectedDevice.record.userId ? "已绑定" : "未绑定",
-                      },
-                      { key: "owner", label: "绑定用户", children: selectedDevice.record.ownerNickname ?? "-" },
-                      { key: "pet", label: "绑定宠物", children: selectedDevice.record.petName ?? "-" },
-                      {
-                        key: "battery",
-                        label: "电量",
-                        children: selectedDevice.record.battery == null ? "-" : `${selectedDevice.record.battery}%`,
-                      },
-                      {
-                        key: "signal",
-                        label: "信号",
-                        children: selectedDevice.record.signal == null ? "-" : `${selectedDevice.record.signal} dBm`,
-                      },
-                      { key: "firmware", label: "固件版本", children: selectedDevice.record.firmwareVersion ?? "-" },
-                      { key: "lastOnlineAt", label: "最后在线时间", children: formatTime(selectedDevice.record.lastOnlineAt) },
-                      { key: "createdAt", label: "注册时间", children: formatTime(selectedDevice.record.createdAt) },
-                      { key: "updatedAt", label: "更新时间", children: formatTime(selectedDevice.record.updatedAt) },
-                    ]
-                  : [
-                      { key: "name", label: "设备名称", children: selectedDevice.record.name ?? "-" },
-                      { key: "id", label: "设备 ID", children: selectedDevice.record.id },
-                      { key: "mac", label: "MAC 地址", children: selectedDevice.record.macAddress ?? "-" },
-                      { key: "status", label: "在线状态", children: renderStatus(selectedDevice.record.status) },
-                      {
-                        key: "bound",
-                        label: "绑定状态",
-                        children: selectedDevice.record.activeBindingCount > 0 ? "已绑定" : "未绑定",
-                      },
-                      { key: "owner", label: "绑定用户", children: selectedDevice.record.ownerNickname ?? "-" },
-                      {
-                        key: "pets",
-                        label: "绑定宠物",
-                        children: renderBindingPets(selectedDevice.record.bindingPetNames),
-                      },
-                      { key: "firmware", label: "固件版本", children: selectedDevice.record.firmwareVersion ?? "-" },
-                      { key: "lastOnlineAt", label: "最后在线时间", children: formatTime(selectedDevice.record.lastOnlineAt) },
-                      { key: "createdAt", label: "注册时间", children: formatTime(selectedDevice.record.createdAt) },
-                      { key: "updatedAt", label: "更新时间", children: formatTime(selectedDevice.record.updatedAt) },
-                    ]
-              }
-            />
-
-            <div style={{ display: "flex", justifyContent: "flex-end" }}>
-              <Button onClick={() => setSelectedDevice(null)}>关闭</Button>
-            </div>
-          </Space>
-        ) : null}
-      </Drawer>
+          </Spin>
+        </Card>
+      </Space>
     </>
   );
 }

--- a/packages/admin/src/pages/ImageReview.tsx
+++ b/packages/admin/src/pages/ImageReview.tsx
@@ -62,6 +62,9 @@ const statusMeta: Record<
   done: { label: "已同步", color: "blue" },
 };
 
+const REVIEW_GRID_IMAGE_SIZE = 96;
+const REVIEW_DETAIL_IMAGE_HEIGHT = 180;
+
 function isSameDay(value: string | null | undefined, date: Dayjs) {
   return !!value && dayjs(value).isValid() && dayjs(value).isSame(date, "day");
 }
@@ -94,25 +97,16 @@ function openImageDownload(imageUrl: string, fallbackName: string) {
   link.remove();
 }
 
-function formatDeltaText(delta: number, positiveLabel = "较昨日增加", negativeLabel = "较昨日减少") {
-  if (delta === 0) {
-    return "较昨日持平";
+function formatComparedToYesterday(delta: number) {
+  if (delta > 0) {
+    return `较昨日 +${delta}`;
   }
 
-  return `${delta > 0 ? positiveLabel : negativeLabel} ${Math.abs(delta)}`;
-}
-
-function formatRate(value: number) {
-  return `${Math.round(value * 100)}%`;
-}
-
-function getCompletionRate(completed: number, pending: number) {
-  const total = completed + pending;
-  if (total === 0) {
-    return 0;
+  if (delta < 0) {
+    return `较昨日 ${delta}`;
   }
 
-  return completed / total;
+  return "较昨日 0";
 }
 
 function getStatusLabel(status: AvatarStatus) {
@@ -442,14 +436,20 @@ export default function ImageReview() {
     [avatars],
   );
 
-  const todayCompletionRate = useMemo(
-    () => getCompletionRate(todayCompletedCount, todayPendingCount),
-    [todayCompletedCount, todayPendingCount],
+  const todaySyncedCount = useMemo(
+    () =>
+      avatars.filter(
+        (avatar) => avatar.status === "done" && isSameDay(avatar.reviewedAt ?? avatar.createdAt, today),
+      ).length,
+    [avatars, today],
   );
 
-  const yesterdayCompletionRate = useMemo(
-    () => getCompletionRate(yesterdayCompletedCount, yesterdayPendingCount),
-    [yesterdayCompletedCount, yesterdayPendingCount],
+  const yesterdaySyncedCount = useMemo(
+    () =>
+      avatars.filter(
+        (avatar) => avatar.status === "done" && isSameDay(avatar.reviewedAt ?? avatar.createdAt, yesterday),
+      ).length,
+    [avatars, yesterday],
   );
 
   const filteredAvatars = useMemo(() => {
@@ -652,26 +652,19 @@ export default function ImageReview() {
             <Col xs={24} md={8}>
               <Card>
                 <Statistic title="今日待处理" value={todayPendingCount} valueStyle={{ color: "#faad14" }} />
-                <Text type="secondary">{formatDeltaText(todayPendingCount - yesterdayPendingCount)} 项</Text>
+                <Text type="secondary">{formatComparedToYesterday(todayPendingCount - yesterdayPendingCount)}</Text>
               </Card>
             </Col>
             <Col xs={24} md={8}>
               <Card>
                 <Statistic title="今日已完成" value={todayCompletedCount} valueStyle={{ color: "#52c41a" }} />
-                <Text type="secondary">
-                  完成率 {formatRate(todayCompletionRate)}，较昨日
-                  {todayCompletionRate === yesterdayCompletionRate
-                    ? "持平"
-                    : todayCompletionRate > yesterdayCompletionRate
-                      ? `提升 ${formatRate(todayCompletionRate - yesterdayCompletionRate)}`
-                      : `下降 ${formatRate(yesterdayCompletionRate - todayCompletionRate)}`}
-                </Text>
+                <Text type="secondary">{formatComparedToYesterday(todayCompletedCount - yesterdayCompletedCount)}</Text>
               </Card>
             </Col>
             <Col xs={24} md={8}>
               <Card>
                 <Statistic title="已同步设备" value={syncedDeviceCount} valueStyle={{ color: "#1677ff" }} />
-                <Text type="secondary">累计同步成功的设备任务总数</Text>
+                <Text type="secondary">{formatComparedToYesterday(todaySyncedCount - yesterdaySyncedCount)}</Text>
               </Card>
             </Col>
           </Row>
@@ -706,14 +699,14 @@ export default function ImageReview() {
             <Tabs activeKey={activeTab} items={tabItems} onChange={(key) => setActiveTab(key as ReviewTabKey)} />
 
             {filteredAvatars.length > 0 ? (
-              <Row gutter={[16, 16]}>
+              <Row gutter={[12, 12]}>
                 {filteredAvatars.map((avatar) => {
                   const status = statusMeta[avatar.status];
                   const isSelected = avatar.id === selectedAvatarId;
                   const petName = avatar.pet?.name ?? "未命名宠物";
 
                   return (
-                    <Col xs={24} sm={12} xl={8} xxl={6} key={avatar.id}>
+                    <Col xs={12} sm={8} md={6} lg={6} xl={4} xxl={3} key={avatar.id}>
                       <Card
                         hoverable
                         onClick={() => setSelectedAvatarId(avatar.id)}
@@ -721,43 +714,61 @@ export default function ImageReview() {
                           borderColor: isSelected ? "#1677ff" : undefined,
                           boxShadow: isSelected ? "0 0 0 2px rgba(22,119,255,0.12)" : undefined,
                         }}
-                        bodyStyle={{ padding: 12 }}
+                        bodyStyle={{ padding: 8 }}
                       >
-                        <Space direction="vertical" size={12} style={{ display: "flex" }}>
-                          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12 }}>
-                            <Title level={5} style={{ margin: 0 }}>
-                              {petName}
-                            </Title>
-                            <Tag color={status.color} style={{ marginInlineEnd: 0 }}>
-                              {status.label}
-                            </Tag>
-                          </div>
-
+                        <div>
                           <div
                             style={{
-                              height: 180,
+                              width: "100%",
+                              aspectRatio: "1 / 1",
                               overflow: "hidden",
-                              borderRadius: 12,
+                              borderRadius: 8,
                               background: "#f5f5f5",
+                              position: "relative",
+                              marginBottom: 8,
                             }}
                           >
+                            <Tag
+                              color={status.color}
+                              style={{
+                                position: "absolute",
+                                top: 6,
+                                right: 6,
+                                marginInlineEnd: 0,
+                                fontSize: 11,
+                                lineHeight: "18px",
+                                paddingInline: 6,
+                                zIndex: 1,
+                              }}
+                            >
+                              {status.label}
+                            </Tag>
                             <Image
                               alt={petName}
                               src={avatar.sourceImageUrl}
                               width="100%"
-                              height={180}
+                              height={REVIEW_GRID_IMAGE_SIZE}
                               preview={false}
                               style={{ objectFit: "cover" }}
                             />
                           </div>
 
-                          <Space size={[8, 8]} wrap>
-                            <Tag>{getSpeciesLabel(avatar.pet?.species)}</Tag>
-                            {avatar.user?.nickname ? <Tag color="blue">{avatar.user.nickname}</Tag> : null}
-                          </Space>
-
-                          <Text type="secondary">上传时间：{formatDateTime(avatar.createdAt)}</Text>
-                        </Space>
+                          <Text
+                            strong
+                            style={{
+                              fontSize: 12,
+                              lineHeight: 1.25,
+                              display: "block",
+                              marginBottom: 2,
+                            }}
+                            ellipsis={{ tooltip: petName }}
+                          >
+                            {petName}
+                          </Text>
+                          <Text type="secondary" style={{ fontSize: 11, lineHeight: 1.2 }}>
+                            {formatDateTime(avatar.createdAt)}
+                          </Text>
+                        </div>
                       </Card>
                     </Col>
                   );
@@ -784,7 +795,7 @@ export default function ImageReview() {
                     <Col xs={24} lg={12}>
                       <div
                         style={{
-                          minHeight: 360,
+                          minHeight: REVIEW_DETAIL_IMAGE_HEIGHT,
                           borderRadius: 16,
                           overflow: "hidden",
                           background: "#f5f5f5",
@@ -794,7 +805,7 @@ export default function ImageReview() {
                           alt={selectedAvatarDetail.pet?.name ?? "宠物图片"}
                           src={selectedAvatarDetail.sourceImageUrl}
                           width="100%"
-                          height={360}
+                          height={REVIEW_DETAIL_IMAGE_HEIGHT}
                           style={{ objectFit: "cover" }}
                         />
                       </div>

--- a/packages/admin/src/pages/Users.tsx
+++ b/packages/admin/src/pages/Users.tsx
@@ -1,11 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { TableProps } from "antd";
 import {
-  Alert,
   Button,
   Card,
-  Descriptions,
-  Drawer,
   Form,
   Input,
   InputNumber,
@@ -15,16 +12,20 @@ import {
   Spin,
   Table,
   Tag,
+  Typography,
   message,
 } from "antd";
-import { PlusOutlined } from "@ant-design/icons";
+import { ArrowLeftOutlined, CheckSquareFilled, PlusOutlined } from "@ant-design/icons";
 import { api } from "../api/client";
 import dayjs from "dayjs";
+
+const { Text, Title } = Typography;
 
 interface UserRecord {
   id: string;
   nickname: string;
   phone: string | null;
+  email: string | null;
   wechatOpenid: string | null;
   avatarUrl: string | null;
   avatarQuota: number;
@@ -79,31 +80,56 @@ interface UserDetail {
   };
 }
 
-const statusColors: Record<string, string> = {
-  online: "green",
-  offline: "default",
-  pairing: "blue",
-};
-
-const statusLabels: Record<string, string> = {
-  online: "在线",
-  offline: "离线",
-  pairing: "配对中",
-};
-
-const speciesLabels: Record<string, string> = {
-  cat: "猫",
-  dog: "狗",
-};
-
-const genderLabels: Record<string, string> = {
-  male: "公",
-  female: "母",
-  unknown: "未知",
-};
+const membershipPerks = [
+  { label: "尊享 60fps 帧率", enabled: true },
+  { label: "优先生成权", enabled: true },
+  { label: "无限定制额度", enabled: false },
+  { label: "专属客服支持", enabled: false },
+] as const;
 
 function formatTime(value: string | null | undefined) {
   return value ? dayjs(value).format("YYYY-MM-DD HH:mm") : "-";
+}
+
+function buildDisplayEmail(user: Pick<UserRecord, "email" | "phone" | "nickname" | "id">) {
+  if (user.email) {
+    return user.email;
+  }
+
+  if (user.phone) {
+    return `${user.phone}@yehey.pet`;
+  }
+
+  const slug = user.nickname.replace(/\s+/g, "").toLowerCase() || user.id.slice(0, 6);
+  return `${slug}@example.com`;
+}
+
+function buildDisplayUserCode(user: Pick<UserRecord, "id" | "nickname">) {
+  return `${user.id.slice(0, 8)}(${user.nickname})`;
+}
+
+function getMembershipLevel(quota: number) {
+  if (quota >= 8) {
+    return "黄金会员";
+  }
+
+  if (quota >= 4) {
+    return "白银会员";
+  }
+
+  return "普通会员";
+}
+
+function getMembershipColor(level: string) {
+  if (level === "黄金会员") {
+    return "#f59e0b";
+  }
+
+  if (level === "白银会员") {
+    return "#64748b";
+  }
+
+  return "#2563eb";
 }
 
 export default function UsersPage() {
@@ -111,10 +137,11 @@ export default function UsersPage() {
   const [loading, setLoading] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [detailOpen, setDetailOpen] = useState(false);
   const [detailUserId, setDetailUserId] = useState<string | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [detail, setDetail] = useState<UserDetail | null>(null);
+  const [savingQuota, setSavingQuota] = useState(false);
+  const [quotaValue, setQuotaValue] = useState<number>(0);
   const [form] = Form.useForm();
 
   const load = () => {
@@ -128,7 +155,7 @@ export default function UsersPage() {
   useEffect(load, []);
 
   useEffect(() => {
-    if (!detailOpen || !detailUserId) {
+    if (!detailUserId) {
       return;
     }
 
@@ -140,9 +167,10 @@ export default function UsersPage() {
 
       try {
         const result = await api.getUserDetail(userId);
-
         if (!cancelled) {
-          setDetail(result as UserDetail);
+          const nextDetail = result as UserDetail;
+          setDetail(nextDetail);
+          setQuotaValue(nextDetail.user.avatarQuota);
         }
       } catch (e) {
         if (!cancelled) {
@@ -160,7 +188,7 @@ export default function UsersPage() {
     return () => {
       cancelled = true;
     };
-  }, [detailOpen, detailUserId]);
+  }, [detailUserId]);
 
   const handleSubmit = async () => {
     try {
@@ -177,14 +205,16 @@ export default function UsersPage() {
       form.resetFields();
       setEditingId(null);
       load();
-      if (currentEditingId && detailOpen && detailUserId === currentEditingId) {
-        setDetailLoading(true);
+      if (currentEditingId && detailUserId === currentEditingId) {
         const result = await api.getUserDetail(currentEditingId);
-        setDetail(result as UserDetail);
-        setDetailLoading(false);
+        const nextDetail = result as UserDetail;
+        setDetail(nextDetail);
+        setQuotaValue(nextDetail.user.avatarQuota);
       }
     } catch (e: any) {
-      if (e.message) message.error(e.message);
+      if (e.message) {
+        message.error(e.message);
+      }
     }
   };
 
@@ -198,6 +228,10 @@ export default function UsersPage() {
     try {
       await api.deleteUser(id);
       message.success("删除成功");
+      if (detailUserId === id) {
+        setDetailUserId(null);
+        setDetail(null);
+      }
       load();
     } catch (e: any) {
       message.error(e.message);
@@ -206,10 +240,35 @@ export default function UsersPage() {
 
   const handleOpenDetail = (record: UserRecord) => {
     setDetailUserId(record.id);
-    setDetailOpen(true);
   };
 
-  const petNameMap = new Map(detail?.pets.map((pet) => [pet.id, pet.name]) ?? []);
+  const handleSaveQuota = async () => {
+    if (!detail) {
+      return;
+    }
+
+    setSavingQuota(true);
+
+    try {
+      await api.updateUser(detail.user.id, { avatarQuota: quotaValue });
+      message.success("配额已保存");
+      const nextDetail = {
+        ...detail,
+        user: {
+          ...detail.user,
+          avatarQuota: quotaValue,
+        },
+      };
+      setDetail(nextDetail);
+      setData((prev) =>
+        prev.map((item) => (item.id === detail.user.id ? { ...item, avatarQuota: quotaValue } : item)),
+      );
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : "配额保存失败");
+    } finally {
+      setSavingQuota(false);
+    }
+  };
 
   const columns: TableProps<UserRecord>["columns"] = [
     { title: "ID", dataIndex: "id", key: "id", width: 200, ellipsis: true },
@@ -232,16 +291,9 @@ export default function UsersPage() {
                 width: 32,
                 height: 32,
                 borderRadius: "50%",
-                background: "#f0f0f0",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                color: "#8c8c8c",
-                fontSize: 12,
+                background: "#3b82f6",
               }}
-            >
-              无图
-            </div>
+            />
           )}
           <span>{record.nickname}</span>
         </Space>
@@ -290,11 +342,241 @@ export default function UsersPage() {
     },
   ];
 
+  const detailUser = detail?.user ?? data.find((item) => item.id === detailUserId) ?? null;
+  const listSelectedUser = data.find((item) => item.id === detailUserId) ?? null;
+
+  const membershipLevel = useMemo(
+    () => (detailUser ? getMembershipLevel(detailUser.avatarQuota) : "普通会员"),
+    [detailUser],
+  );
+
+  const membershipExpireAt = useMemo(
+    () => (detailUser ? dayjs(detailUser.createdAt).add(1, "year").format("YYYY-MM-DD") : "-"),
+    [detailUser],
+  );
+
+  const boundDevices = useMemo(
+    () => (detail ? detail.devices.collars.length + detail.devices.desktops.length : listSelectedUser?.deviceCount ?? 0),
+    [detail, listSelectedUser],
+  );
+
+  const displayEmail = useMemo(
+    () => (detailUser ? buildDisplayEmail(detailUser) : "-"),
+    [detailUser],
+  );
+
+  const displayCode = useMemo(
+    () => (detailUser ? buildDisplayUserCode(detailUser) : "-"),
+    [detailUser],
+  );
+
+  if (detailUserId && detailUser) {
+    return (
+      <>
+        <Space direction="vertical" size={16} style={{ display: "flex" }}>
+          <Button
+            type="link"
+            icon={<ArrowLeftOutlined />}
+            style={{ padding: 0, width: "fit-content" }}
+            onClick={() => {
+              setDetailUserId(null);
+              setDetail(null);
+            }}
+          >
+            返回列表
+          </Button>
+
+          <Spin spinning={detailLoading}>
+            <Space direction="vertical" size={16} style={{ display: "flex" }}>
+              <Card title={<Text strong style={{ fontSize: 15 }}>用户基本信息</Text>} styles={{ body: { padding: 18 } }}>
+                <div
+                  style={{
+                    padding: 18,
+                    borderRadius: 14,
+                    background: "#f8fafc",
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 16,
+                  }}
+                >
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "flex-start", flexWrap: "wrap" }}>
+                    <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+                      {detailUser.avatarUrl ? (
+                        <img
+                          src={detailUser.avatarUrl}
+                          alt={detailUser.nickname}
+                          style={{ width: 64, height: 64, borderRadius: "50%", objectFit: "cover" }}
+                        />
+                      ) : (
+                        <div
+                          style={{
+                            width: 64,
+                            height: 64,
+                            borderRadius: "50%",
+                            background: "#3b82f6",
+                          }}
+                        />
+                      )}
+
+                      <div>
+                        <Title level={4} style={{ margin: 0, fontSize: 18, lineHeight: 1.3 }}>
+                          {displayCode}
+                        </Title>
+                        <Text type="secondary" style={{ fontSize: 14 }}>
+                          {displayEmail}
+                        </Text>
+                      </div>
+                    </div>
+
+                    <div style={{ textAlign: "right" }}>
+                      <Tag color="success" style={{ marginInlineEnd: 0, paddingInline: 12, lineHeight: "24px", borderRadius: 999, fontSize: 12 }}>
+                        ● 账号正常
+                      </Tag>
+                      <div style={{ marginTop: 12 }}>
+                        <Text type="secondary" style={{ fontSize: 13 }}>{`注册时间: ${dayjs(detailUser.createdAt).format("YYYY-MM-DD")}`}</Text>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+                      gap: 12,
+                    }}
+                  >
+                    <div style={{ padding: 14, borderRadius: 12, background: "#fff" }}>
+                      <Text type="secondary" style={{ fontSize: 13 }}>会员等级</Text>
+                      <div style={{ marginTop: 8 }}>
+                        <Text strong style={{ fontSize: 16, color: getMembershipColor(membershipLevel) }}>
+                          {membershipLevel}
+                        </Text>
+                      </div>
+                    </div>
+                    <div style={{ padding: 14, borderRadius: 12, background: "#fff" }}>
+                      <Text type="secondary" style={{ fontSize: 13 }}>到期时间</Text>
+                      <div style={{ marginTop: 8 }}>
+                        <Text strong style={{ fontSize: 16 }}>{membershipExpireAt}</Text>
+                      </div>
+                    </div>
+                    <div style={{ padding: 14, borderRadius: 12, background: "#fff" }}>
+                      <Text type="secondary" style={{ fontSize: 13 }}>绑定设备</Text>
+                      <div style={{ marginTop: 8 }}>
+                        <Text strong style={{ fontSize: 16 }}>{`${boundDevices} 台`}</Text>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </Card>
+
+              <Card title={<Text strong style={{ fontSize: 15 }}>权益包配置</Text>} styles={{ body: { padding: 18 } }}>
+                <Space direction="vertical" size={14} style={{ display: "flex" }}>
+                  <div
+                    style={{
+                      padding: 16,
+                      borderRadius: 14,
+                      background: "#f8fafc",
+                      display: "flex",
+                      justifyContent: "space-between",
+                      gap: 16,
+                      alignItems: "center",
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <div>
+                      <Title level={5} style={{ margin: 0, fontSize: 16 }}>
+                        定制额度
+                      </Title>
+                      <div style={{ marginTop: 6 }}>
+                        <Text type="secondary" style={{ fontSize: 13 }}>{`剩余免费次数: ${Math.max(0, quotaValue)} 次 / 共 15 次`}</Text>
+                      </div>
+                    </div>
+
+                    <Space size={10}>
+                      <InputNumber
+                        min={0}
+                        value={quotaValue}
+                        onChange={(value) => setQuotaValue(Number(value ?? 0))}
+                        style={{ width: 88 }}
+                      />
+                      <Button type="primary" loading={savingQuota} onClick={() => void handleSaveQuota()}>
+                        保存
+                      </Button>
+                    </Space>
+                  </div>
+
+                  <div>
+                    <Text strong style={{ display: "block", marginBottom: 10, fontSize: 14 }}>
+                      会员等级权益（可勾选）
+                    </Text>
+
+                    <Space direction="vertical" size={10} style={{ display: "flex" }}>
+                      {membershipPerks.map((perk) => (
+                        <div
+                          key={perk.label}
+                          style={{
+                            padding: "12px 14px",
+                            borderRadius: 12,
+                            background: "#f8fafc",
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 10,
+                          }}
+                        >
+                          <CheckSquareFilled style={{ color: perk.enabled ? "#10b981" : "#cbd5e1", fontSize: 18 }} />
+                          <Text style={{ fontSize: 14 }}>{perk.label}</Text>
+                        </div>
+                      ))}
+                    </Space>
+                  </div>
+                </Space>
+              </Card>
+            </Space>
+          </Spin>
+        </Space>
+
+        <Modal
+          title={editingId ? "编辑用户" : "新建用户"}
+          open={modalOpen}
+          onOk={handleSubmit}
+          onCancel={() => {
+            setModalOpen(false);
+            setEditingId(null);
+            form.resetFields();
+          }}
+        >
+          <Form form={form} layout="vertical">
+            <Form.Item name="nickname" label="昵称" rules={[{ required: true }]}>
+              <Input />
+            </Form.Item>
+            <Form.Item name="phone" label="手机号">
+              <Input />
+            </Form.Item>
+            <Form.Item name="wechatOpenid" label="微信 OpenID">
+              <Input />
+            </Form.Item>
+            <Form.Item name="avatarQuota" label="形象配额">
+              <InputNumber min={0} style={{ width: "100%" }} />
+            </Form.Item>
+          </Form>
+        </Modal>
+      </>
+    );
+  }
+
   return (
     <>
       <div style={{ marginBottom: 16, display: "flex", justifyContent: "space-between" }}>
-        <h2 style={{ margin: 0 }}>用户管理</h2>
-        <Button type="primary" icon={<PlusOutlined />} onClick={() => { setEditingId(null); form.resetFields(); setModalOpen(true); }}>
+        <h2 style={{ margin: 0 }}>用户会员</h2>
+        <Button
+          type="primary"
+          icon={<PlusOutlined />}
+          onClick={() => {
+            setEditingId(null);
+            form.resetFields();
+            setModalOpen(true);
+          }}
+        >
           新建用户
         </Button>
       </div>
@@ -314,7 +596,11 @@ export default function UsersPage() {
         title={editingId ? "编辑用户" : "新建用户"}
         open={modalOpen}
         onOk={handleSubmit}
-        onCancel={() => { setModalOpen(false); setEditingId(null); form.resetFields(); }}
+        onCancel={() => {
+          setModalOpen(false);
+          setEditingId(null);
+          form.resetFields();
+        }}
       >
         <Form form={form} layout="vertical">
           <Form.Item name="nickname" label="昵称" rules={[{ required: true }]}>
@@ -331,182 +617,6 @@ export default function UsersPage() {
           </Form.Item>
         </Form>
       </Modal>
-      <Drawer
-        title="用户详情"
-        width={760}
-        open={detailOpen}
-        onClose={() => setDetailOpen(false)}
-        destroyOnClose={false}
-      >
-        <Spin spinning={detailLoading}>
-          {detail ? (
-            <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-              <Card title="基本信息">
-                <Descriptions bordered column={2} size="small">
-                  <Descriptions.Item label="用户 ID" span={2}>
-                    {detail.user.id}
-                  </Descriptions.Item>
-                  <Descriptions.Item label="昵称">{detail.user.nickname}</Descriptions.Item>
-                  <Descriptions.Item label="头像配额">{detail.user.avatarQuota}</Descriptions.Item>
-                  <Descriptions.Item label="手机号">{detail.user.phone || "-"}</Descriptions.Item>
-                  <Descriptions.Item label="微信 OpenID">{detail.user.wechatOpenid || "-"}</Descriptions.Item>
-                  <Descriptions.Item label="宠物数">{detail.pets.length}</Descriptions.Item>
-                  <Descriptions.Item label="绑定设备数">
-                    {detail.devices.collars.length + detail.devices.desktops.length}
-                  </Descriptions.Item>
-                  <Descriptions.Item label="注册时间">{formatTime(detail.user.createdAt)}</Descriptions.Item>
-                  <Descriptions.Item label="更新时间">{formatTime(detail.user.updatedAt)}</Descriptions.Item>
-                </Descriptions>
-              </Card>
-
-              <Card
-                title="宠物列表"
-                extra={<Tag color="blue">{detail.pets.length}</Tag>}
-              >
-                <Table<PetRecord>
-                  dataSource={detail.pets}
-                  rowKey="id"
-                  size="small"
-                  pagination={false}
-                  scroll={{ x: 720 }}
-                  columns={[
-                    { title: "名字", dataIndex: "name", key: "name", width: 120 },
-                    {
-                      title: "物种",
-                      dataIndex: "species",
-                      key: "species",
-                      width: 90,
-                      render: (value: string) => speciesLabels[value] ?? value,
-                    },
-                    {
-                      title: "性别",
-                      dataIndex: "gender",
-                      key: "gender",
-                      width: 90,
-                      render: (value: string) => genderLabels[value] ?? value,
-                    },
-                    {
-                      title: "品种",
-                      dataIndex: "breed",
-                      key: "breed",
-                      render: (value: string | null) => value || "-",
-                    },
-                    {
-                      title: "生日",
-                      dataIndex: "birthday",
-                      key: "birthday",
-                      width: 120,
-                      render: (value: string | null) => value || "-",
-                    },
-                    {
-                      title: "创建时间",
-                      dataIndex: "createdAt",
-                      key: "createdAt",
-                      width: 160,
-                      render: (value: string) => formatTime(value),
-                    },
-                  ]}
-                />
-              </Card>
-
-              <Card
-                title="项圈设备"
-                extra={<Tag color="geekblue">{detail.devices.collars.length}</Tag>}
-              >
-                <Table<CollarDeviceRecord>
-                  dataSource={detail.devices.collars}
-                  rowKey="id"
-                  size="small"
-                  pagination={false}
-                  scroll={{ x: 760 }}
-                  columns={[
-                    { title: "名称", dataIndex: "name", key: "name", width: 140 },
-                    { title: "MAC 地址", dataIndex: "macAddress", key: "macAddress", width: 180 },
-                    {
-                      title: "状态",
-                      dataIndex: "status",
-                      key: "status",
-                      width: 90,
-                      render: (value: string) => (
-                        <Tag color={statusColors[value] ?? "default"}>
-                          {statusLabels[value] ?? value}
-                        </Tag>
-                      ),
-                    },
-                    {
-                      title: "绑定宠物",
-                      dataIndex: "petId",
-                      key: "petId",
-                      width: 140,
-                      render: (value: string | null) => (value ? petNameMap.get(value) ?? value : "-"),
-                    },
-                    {
-                      title: "电量",
-                      dataIndex: "battery",
-                      key: "battery",
-                      width: 90,
-                      render: (value: number | null) => (value == null ? "-" : `${value}%`),
-                    },
-                    {
-                      title: "最后在线",
-                      dataIndex: "lastOnlineAt",
-                      key: "lastOnlineAt",
-                      width: 160,
-                      render: (value: string | null) => formatTime(value),
-                    },
-                  ]}
-                />
-              </Card>
-
-              <Card
-                title="桌面端设备"
-                extra={<Tag color="purple">{detail.devices.desktops.length}</Tag>}
-              >
-                <Table<DesktopDeviceRecord>
-                  dataSource={detail.devices.desktops}
-                  rowKey="id"
-                  size="small"
-                  pagination={false}
-                  scroll={{ x: 720 }}
-                  columns={[
-                    { title: "名称", dataIndex: "name", key: "name", width: 140 },
-                    { title: "MAC 地址", dataIndex: "macAddress", key: "macAddress", width: 180 },
-                    {
-                      title: "状态",
-                      dataIndex: "status",
-                      key: "status",
-                      width: 90,
-                      render: (value: string) => (
-                        <Tag color={statusColors[value] ?? "default"}>
-                          {statusLabels[value] ?? value}
-                        </Tag>
-                      ),
-                    },
-                    {
-                      title: "固件版本",
-                      dataIndex: "firmwareVersion",
-                      key: "firmwareVersion",
-                      width: 120,
-                      render: (value: string | null) => value || "-",
-                    },
-                    {
-                      title: "最后在线",
-                      dataIndex: "lastOnlineAt",
-                      key: "lastOnlineAt",
-                      width: 160,
-                      render: (value: string | null) => formatTime(value),
-                    },
-                  ]}
-                />
-              </Card>
-
-              <Alert type="info" message="会员功能开发中" showIcon />
-            </div>
-          ) : (
-            <Alert type="info" message="请选择用户查看详情" showIcon />
-          )}
-        </Spin>
-      </Drawer>
     </>
   );
 }

--- a/packages/server/src/routes/admin/avatars.ts
+++ b/packages/server/src/routes/admin/avatars.ts
@@ -24,6 +24,9 @@ type AvatarRow = {
   petId: string | null;
   petName: string | null;
   petSpecies: string | null;
+  petBreed: string | null;
+  petGender: string | null;
+  petBirthday: string | null;
   userId: string | null;
   userNickname: string | null;
   userAvatarUrl: string | null;
@@ -44,10 +47,13 @@ function toAvatarResponse(row: AvatarRow) {
   return {
     ...row.avatar,
     pet: row.petId
-      ? {
+        ? {
           id: row.petId,
           name: row.petName,
           species: row.petSpecies,
+          breed: row.petBreed,
+          gender: row.petGender,
+          birthday: row.petBirthday,
         }
       : null,
     user: row.userId
@@ -69,6 +75,9 @@ async function getAvatarRow(avatarId: string) {
       petId: pets.id,
       petName: pets.name,
       petSpecies: pets.species,
+      petBreed: pets.breed,
+      petGender: pets.gender,
+      petBirthday: pets.birthday,
       userId: users.id,
       userNickname: users.nickname,
       userAvatarUrl: users.avatarUrl,
@@ -116,6 +125,9 @@ avatarsRoute.get("/avatars", async (c) => {
       petId: pets.id,
       petName: pets.name,
       petSpecies: pets.species,
+      petBreed: pets.breed,
+      petGender: pets.gender,
+      petBirthday: pets.birthday,
       userId: users.id,
       userNickname: users.nickname,
       userAvatarUrl: users.avatarUrl,

--- a/packages/server/src/routes/admin/devices.ts
+++ b/packages/server/src/routes/admin/devices.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { and, asc, desc, eq, isNotNull, isNull, type SQL } from "drizzle-orm";
 import { db } from "../../db";
-import { users, pets, collarDevices, desktopDevices, desktopPetBindings, petBehaviors } from "../../db/schema";
+import { users, pets, collarDevices, desktopDevices, desktopPetBindings, petAvatars, petBehaviors } from "../../db/schema";
 import { createId } from "../../utils/id";
 import { pick } from "./utils";
 
@@ -24,7 +24,47 @@ type AdminDesktopRow = {
   bindingId: string | null;
   bindingPetId: string | null;
   bindingPetName: string | null;
+  bindingPetSpecies: string | null;
+  avatarId: string | null;
 };
+
+type AdminCollarRow = {
+  collar: typeof collarDevices.$inferSelect;
+  ownerNickname: string | null;
+  petName: string | null;
+  petSpecies: string | null;
+  avatarId: string | null;
+};
+
+function mapCollarRows(rows: AdminCollarRow[]) {
+  const collars = new Map<
+    string,
+    typeof collarDevices.$inferSelect & {
+      ownerNickname: string | null;
+      petName: string | null;
+      petSpecies: string | null;
+      hasUploadedImage: boolean;
+    }
+  >();
+
+  for (const row of rows) {
+    const existing = collars.get(row.collar.id);
+    if (existing) {
+      existing.hasUploadedImage = existing.hasUploadedImage || !!row.avatarId;
+      continue;
+    }
+
+    collars.set(row.collar.id, {
+      ...row.collar,
+      ownerNickname: row.ownerNickname,
+      petName: row.petName,
+      petSpecies: row.petSpecies,
+      hasUploadedImage: !!row.avatarId,
+    });
+  }
+
+  return Array.from(collars.values());
+}
 
 function mapDesktopRows(rows: AdminDesktopRow[]) {
   const desktops = new Map<
@@ -32,7 +72,9 @@ function mapDesktopRows(rows: AdminDesktopRow[]) {
     typeof desktopDevices.$inferSelect & {
       ownerNickname: string | null;
       bindingPetNames: string[];
+      bindingPetSpeciesList: string[];
       activeBindingCount: number;
+      hasUploadedImage: boolean;
     }
   >();
 
@@ -43,6 +85,10 @@ function mapDesktopRows(rows: AdminDesktopRow[]) {
       if (row.bindingId && !existing.bindingPetNames.includes(bindingPetLabel)) {
         existing.bindingPetNames.push(bindingPetLabel);
       }
+      if (row.bindingPetSpecies && !existing.bindingPetSpeciesList.includes(row.bindingPetSpecies)) {
+        existing.bindingPetSpeciesList.push(row.bindingPetSpecies);
+      }
+      existing.hasUploadedImage = existing.hasUploadedImage || !!row.avatarId;
       continue;
     }
 
@@ -50,7 +96,9 @@ function mapDesktopRows(rows: AdminDesktopRow[]) {
       ...row.desktop,
       ownerNickname: row.ownerNickname,
       bindingPetNames: row.bindingId ? [bindingPetLabel] : [],
+      bindingPetSpeciesList: row.bindingPetSpecies ? [row.bindingPetSpecies] : [],
       activeBindingCount: 0,
+      hasUploadedImage: !!row.avatarId,
     });
   }
 
@@ -91,18 +139,17 @@ devicesRoute.get("/collars", async (c) => {
       collar: collarDevices,
       ownerNickname: users.nickname,
       petName: pets.name,
+      petSpecies: pets.species,
+      avatarId: petAvatars.id,
     })
     .from(collarDevices)
     .leftJoin(users, eq(collarDevices.userId, users.id))
     .leftJoin(pets, eq(collarDevices.petId, pets.id))
+    .leftJoin(petAvatars, eq(collarDevices.petId, petAvatars.petId))
     .where(filters.length > 0 ? and(...filters) : undefined)
     .orderBy(orderBy);
   return c.json({
-    collars: result.map((row) => ({
-      ...row.collar,
-      ownerNickname: row.ownerNickname,
-      petName: row.petName,
-    })),
+    collars: mapCollarRows(result as AdminCollarRow[]),
   });
 });
 
@@ -172,6 +219,8 @@ devicesRoute.get("/desktops", async (c) => {
       bindingId: desktopPetBindings.id,
       bindingPetId: desktopPetBindings.petId,
       bindingPetName: pets.name,
+      bindingPetSpecies: pets.species,
+      avatarId: petAvatars.id,
     })
     .from(desktopDevices)
     .leftJoin(users, eq(desktopDevices.userId, users.id))
@@ -183,6 +232,7 @@ devicesRoute.get("/desktops", async (c) => {
       ),
     )
     .leftJoin(pets, eq(desktopPetBindings.petId, pets.id))
+    .leftJoin(petAvatars, eq(desktopPetBindings.petId, petAvatars.petId))
     .where(filters.length > 0 ? and(...filters) : undefined)
     .orderBy(orderBy);
   return c.json({


### PR DESCRIPTION
## What changed

This PR polishes the admin backoffice UI and supporting admin API payloads to align the current management console more closely with the latest product direction.

Key updates include:

- reordered the left navigation to the latest agreed information architecture
- refreshed the image review page summary copy and compacted the review card layout
- rebuilt the customization center into a left-list / right-detail workflow and added demo fallback data for empty states
- redesigned the devices page into a unified list + full-page detail view with refined filters, labels, and management layout
- rebuilt the user membership detail page into a full-page profile + membership rights configuration view
- extended admin avatar/device API responses with extra fields needed by the new layouts
- corrected device model copy to `桌面宠物1.0`

## Why

The previous admin pages were structurally incomplete for the latest operating flow and did not match the intended presentation for image review, customization tasks, device management, and user membership management. This PR brings the pages into a much more reviewable and demoable state for the current product iteration.

## Impact

- product and design can now review a much closer version of the intended admin backoffice experience
- device, review, customization, and membership flows are easier to inspect end to end
- some views still contain front-end derived data or demo fallback behavior where backend detail APIs are not yet fully available

## Validation

- `pnpm --filter admin build`
- `pnpm --filter server build`

## Notes

- this PR is opened as a draft because there are still follow-up items around backend completeness for certain detail views and task summaries
- no unrelated workspace changes were included in this branch
