### PR TITLE
后端补齐：设备管理 / 定制中心 / 用户会员 / 图像审核

### DIFF
--- a/docs/specs/260417-admin-backend-completion/design.md
+++ b/docs/specs/260417-admin-backend-completion/design.md
@@ -1,0 +1,578 @@
+# 技术设计：后端补齐
+
+对应需求：`requirements.md`（D-01..D-16、UBI-01..UBI-08）。
+
+## 0. 需求修正
+
+- **修正 D-07**：shared 已有 `BASIC_ACTIONS`(6) + `FUN_ACTIONS`(8) = `ALL_ACTIONS`(14)。不新建 `ACTION_CATALOG`，直接复用 shared 常量；base = `BASIC_ACTIONS`，personalized = `FUN_ACTIONS`。前端硬编码的 `18` 是错误假设，必须改为读取接口返回的总数。
+- **修正 D-03**：白名单不是泛化的 `image/*`，而是明确枚举 `image/jpeg | image/png | image/webp`。预签名 PUT 必须绑定具体 `Content-Type`，否则白名单约束形同虚设。
+- **修正 D-06**：当前 schema 没有项圈绑定历史表，`companionDays` 对项圈只能按 `collar_devices.created_at` 近似计算，不能用 `updatedAt` 硬猜，更不能额外发明 `pet code` 之类需求外字段。
+
+## 1. 架构总览
+
+```text
+packages/server/src/
+├── db/schema.ts              (+ memberships 表 + membership_level enum + 查询所需索引)
+├── routes/admin/
+│   ├── index.ts              (挂新路由)
+│   ├── devices.ts            (现状保留 + 新增 /devices 统一列表 + /devices/:type/:id/detail)
+│   ├── customization.ts      (新文件：/customization/tasks)
+│   ├── memberships.ts        (新文件：/users/:id/membership GET/PUT)
+│   ├── avatars.ts            (现状保留 + 新增 /avatar-review/stats)
+│   └── uploads.ts            (新文件：/uploads/presign)
+├── utils/
+│   ├── pagination.ts         (新文件：parsePagination + buildPageResponse)
+│   └── storage.ts            (+ createPresignedPutUrl)
+└── scripts/
+    └── seed-admin-demo.ts    (新文件)
+
+packages/shared/src/types.ts      (+ Membership, MembershipLevel, AdminDevice*, CustomizationTask, AvatarReviewStats, PresignResponse)
+packages/shared/src/constants.ts  (+ MEMBERSHIP_LEVEL_LABELS, DEFAULT_FREE_BENEFITS)
+```
+
+## 2. 数据库变更
+
+### 2.1 `memberships` 表
+
+```ts
+export const membershipLevelEnum = pgEnum("membership_level", [
+  "free",
+  "basic",
+  "pro",
+  "premium",
+]);
+
+export const membershipStatusEnum = pgEnum("membership_status", [
+  "active",
+  "expired",
+  "suspended",
+]);
+
+export const memberships = pgTable(
+  "memberships",
+  {
+    id: text("id").primaryKey().$defaultFn(createId),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    level: membershipLevelEnum("level").notNull().default("free"),
+    status: membershipStatusEnum("status").notNull().default("active"),
+    startAt: timestamp("start_at", { withTimezone: true }).notNull().defaultNow(),
+    expireAt: timestamp("expire_at", { withTimezone: true }),
+    benefits: jsonb("benefits").notNull().default(sql`'[]'::jsonb`),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uq_memberships_user_id").on(table.userId),
+  ],
+);
+```
+
+设计约束：
+
+- `user_id` 保持一对一唯一约束，足够支撑 GET/PUT membership 的按用户读写；保留独立 `id` 只是为了与现有 schema 风格一致，不额外引入复合主键。
+- `onDelete: "cascade"` 只用于 `users -> memberships`，这是合理的。当前代码库大部分旧表并没有完整 FK，不能因为这里加了级联就假设 seed 或清理脚本可以“删 user 一把梭”。
+- `benefits` 用 `jsonb` 可以接受，但只适合作为“配置快照”存储，不适合作为查询维度。本期不按 benefits 子字段筛选/排序，因此不要给 `jsonb` 补 GIN，也不要在 SQL 里解析它。
+- `benefits` 写入语义定义为“整包替换”，不做 patch merge。否则空数组、禁用项、删除项三者语义会混在一起。
+- `users.avatarQuota` 保留，作为真实额度字段；`memberships.level` 表示会员等级。写 membership 时同步 `users.avatarQuota`，避免前端和小程序出现双口径。
+
+### 2.2 查询索引
+
+这轮新增接口会直接打到下面这些列。若迁移前不存在索引，补上：
+
+- `pet_avatars(pet_id, created_at desc)`
+- `pet_avatar_actions(pet_avatar_id, sort_order, id)`
+- `desktop_pet_bindings(desktop_device_id, created_at desc) where unbound_at is null`
+- `desktop_pet_bindings(pet_id) where unbound_at is null`
+- `collar_devices(pet_id)`
+
+说明：
+
+- 这些索引是为聚合和 `EXISTS` 子查询服务，不是为了 `%keyword%` 模糊搜索。
+- `keyword` 的 `ILIKE '%xx%'` 在没有 `pg_trgm` 时仍然会扫表；本期不承诺做全文检索，只把 pageSize 限制在 100 并接受 admin 数据量下的线性扫描。
+
+## 3. 分页工具
+
+```ts
+export interface PageParams {
+  page: number;
+  pageSize: number;
+  offset: number;
+}
+
+export function parsePagination(c: Context): PageParams {
+  const page = Math.max(1, Number(c.req.query("page") ?? 1) || 1);
+  const raw = Number(c.req.query("pageSize") ?? 20) || 20;
+  const pageSize = Math.min(100, Math.max(1, raw));
+  return { page, pageSize, offset: (page - 1) * pageSize };
+}
+
+export function buildPageResponse<T>(items: T[], total: number, params: PageParams) {
+  return { items, total, page: params.page, pageSize: params.pageSize };
+}
+```
+
+补充约束：
+
+- 所有列表接口排序都必须带稳定次序，至少补 `id` 作为二级排序键，避免翻页重复/漏项。
+- 统一列表接口用“页查询 + count 查询”两条 SQL，共享同一段过滤 CTE；不要为了省一条 SQL 把 `count(*) over()`、聚合、分页硬搅在一起。
+
+## 4. 接口详设
+
+### 4.1 `GET /admin/devices` （D-04, D-05, UBI-03）
+
+#### 实现原则
+
+- 不采用“先 `UNION ALL` 原始设备行，再在外层继续 JOIN 宠物/头像/绑定明细”的写法。那样 desktop 多绑定、pet 多 avatar 时会直接把行数放大，分页和 `total` 都会失真。
+- 正确做法是“**先按设备聚平成一行，再 `UNION ALL`**”：
+  1. `avatar_stats_by_pet`：按 `pet_id` 预聚合头像是否已上传、动作上传数、最新展示图。
+  2. `desktop_binding_stats`：按 `desktop_device_id` 预聚合 `binding_count`，并选一个代表宠物用于扁平展示。
+  3. `collar_rows`：每台项圈一行。
+  4. `desktop_rows`：每台桌面端一行。
+  5. `merged_devices`：`UNION ALL collar_rows + desktop_rows` 后再做统一筛选、排序、分页。
+- 这个查询在 Drizzle 0.39 上可以拼出来，但可读性和可维护性都差。这里直接允许 `db.execute(sql\`...\`)` 写带 CTE 的 SQL，返回结果再映射到 shared 类型。不要为了“全 Drizzle builder”牺牲可控性。
+
+#### 字段口径
+
+- `bindingStatus`
+  - collar：`petId IS NOT NULL` 视为 `bound`
+  - desktop：`bindingCount > 0` 视为 `bound`
+- `bindingCount`
+  - collar：0 或 1
+  - desktop：`desktop_pet_bindings.unbound_at IS NULL` 的 active 绑定数
+- `petId / petName / petSpecies / petAvatarUrl`
+  - collar：直接取 `collar_devices.pet_id`
+  - desktop：只暴露一个“代表宠物”做扁平展示，选 `created_at desc, id desc` 的最新 active binding
+- `species` / `imageStatus` 过滤
+  - desktop 不能只看代表宠物，否则会误筛
+  - 必须对该 desktop 的全部 active bindings 做 `EXISTS` 判断
+- `hasUploadedAvatar`
+  - 沿用需求口径：对应宠物存在 `pet_avatars.status in ('approved', 'done')`
+- `avatarProgress`
+  - 从 `avatar_stats_by_pet` 一次性 left join 取回
+  - 绝不在列表结果上为每行再跑多个相关子查询
+
+#### 性能与分页
+
+- `page` 查询和 `count` 查询共享同一套过滤条件，但分别执行。这样最稳，不会把 count 的聚合成本塞进每一页。
+- `sort` 支持 `createdAt | lastOnlineAt`，`order` 默认 `desc`；二级排序统一补 `type asc, id desc`。
+- `keyword` 命中 `name / macAddress / userNickname`，采用 `ILIKE`。这是当前唯一允许的全表扫描点，不再叠加更多复杂搜索。
+
+#### 代表 SQL 结构
+
+```sql
+WITH avatar_stats_by_pet AS (
+  SELECT
+    pa.pet_id,
+    BOOL_OR(pa.status IN ('approved', 'done')) AS has_uploaded_avatar,
+    MAX(NULLIF(pa.source_image_url, '')) FILTER (WHERE pa.status IN ('approved', 'done')) AS pet_avatar_url,
+    COUNT(*) FILTER (
+      WHERE act.action_type = ANY($1::text[])
+    )::int AS uploaded_actions
+  FROM pet_avatars pa
+  LEFT JOIN pet_avatar_actions act ON act.pet_avatar_id = pa.id
+  GROUP BY pa.pet_id
+),
+desktop_binding_stats AS (
+  SELECT
+    b.desktop_device_id,
+    COUNT(*)::int AS binding_count,
+    (
+      ARRAY_AGG(b.pet_id ORDER BY b.created_at DESC, b.id DESC)
+    )[1] AS representative_pet_id
+  FROM desktop_pet_bindings b
+  WHERE b.unbound_at IS NULL
+  GROUP BY b.desktop_device_id
+),
+collar_rows AS (...),
+desktop_rows AS (...),
+merged_devices AS (
+  SELECT * FROM collar_rows
+  UNION ALL
+  SELECT * FROM desktop_rows
+)
+SELECT *
+FROM merged_devices
+WHERE ...
+ORDER BY created_at DESC, type ASC, id DESC
+LIMIT $limit OFFSET $offset;
+```
+
+### 4.2 `GET /admin/devices/:type/:id/detail` （D-06, UBI-02）
+
+- `type` 仅允许 `collar | desktop`。
+- 现有 `routes/admin/devices.ts` 保持原 `/collars`、`/desktops`、CRUD 行为不变，只新增新的 detail handler；不要改老接口返回结构。
+- 返回结构：
+  - `device`：设备基础信息
+  - `owner`：`{id, nickname, avatarUrl}` 或 `null`
+  - `pet`
+    - collar：取 `collar_devices.pet_id`
+    - desktop：取最新 active binding 对应宠物
+    - `avatarUrl`：优先该宠物最近一条 `status in ('approved', 'done')` 的 `sourceImageUrl`
+    - `companionDays`
+      - desktop：按 active binding 的 `created_at` 精确计算
+      - collar：schema 无绑定历史，只能按 `collar_devices.created_at` 近似计算；不要用 `updatedAt`
+  - `relatedDevices`：同一 owner 下、去掉自身的其他设备，仍按扁平结构返回最小必要字段
+  - `avatarProgress`：`{ total, uploaded, approved, pending }`
+  - `lastSyncedAt`：暂用 `lastOnlineAt`
+  - `activatedAt`：`createdAt`
+
+说明：
+
+- 需求没有要求 `pet code`，设计里不新增这类猜测字段。
+- `relatedDevices` 不做跨宠物复杂排序，只按“最近在线优先，再 createdAt desc”即可。
+
+### 4.3 `GET /admin/customization/tasks` （D-08, D-09, UBI-01）
+
+- 参数：`keyword`、`status`（逗号分隔，值属于 `avatar_status`）、`category`（`base | personalized | all`）、`page`、`pageSize`。
+- 基础查询：`pet_avatars` JOIN `pets` JOIN `users`。
+- 动作计数：按 `pet_avatar_id` 做一次聚合，使用 `COUNT(*) FILTER (...)` 计算 `baseActionCount` 和 `personalizedActionCount`，不要为每一行写两个标量子查询。
+- `defaultPreviewUrl`
+  - 先取 `NULLIF(pet_avatars.source_image_url, '')`
+  - 若为空，再取该 avatar 第一条 action 图 `ORDER BY sort_order ASC, id ASC LIMIT 1`
+  - 这是为了兼容“字段非 null 但可能写入空串”的脏数据
+
+#### `categoryStatus` 定义
+
+先定义：
+
+- `baseActionTotal = BASIC_ACTIONS.length = 6`
+- `personalizedActionTotal = FUN_ACTIONS.length = 8`
+- `baseDone = baseActionCount >= baseActionTotal`
+- `personalizedDone = personalizedActionCount >= personalizedActionTotal`
+
+再映射：
+
+- `empty`：`baseActionCount = 0 AND personalizedActionCount = 0`
+- `all_done`：`baseDone AND personalizedDone`
+- `base_done`：`baseDone AND NOT personalizedDone`
+- `partial`：其他所有情况
+
+这样可以覆盖 `personalized > 0 且 base = 0` 这种异常但真实可能出现的数据，不会产生不可归类状态。
+
+#### `category` 筛选语义
+
+- `all`：不筛
+- `base`：`baseActionCount > 0`
+- `personalized`：`personalizedActionCount > 0`
+
+这里的 `category` 表示“关注哪一类动作”，不是“只保留纯 base、没有任何 personalized 的任务”。否则会把大量已经进入个性化阶段的任务从 base 视图里错误排除。
+
+#### 返回字段
+
+每条 item 返回：
+
+- `avatarId`
+- `petId`
+- `petName`
+- `petSpecies`
+- `userId`
+- `userNickname`
+- `status`
+- `defaultPreviewUrl`
+- `baseActionCount`
+- `personalizedActionCount`
+- `totalActionCount`
+- `baseActionTotal`
+- `personalizedActionTotal`
+- `categoryStatus`
+- `isNewToday`
+- `createdAt`
+- `reviewedAt`
+
+### 4.4 `POST /admin/uploads/presign` （D-03, UBI-05）
+
+依赖：补 `@aws-sdk/s3-request-presigner`。
+
+```ts
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+const ALLOWED_CONTENT_TYPES = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+} as const;
+
+export async function createPresignedPutUrl(opts: {
+  contentType: keyof typeof ALLOWED_CONTENT_TYPES;
+  scope?: string;
+}) {
+  await ensureBucket();
+
+  const now = new Date();
+  const ext = ALLOWED_CONTENT_TYPES[opts.contentType];
+  const key = `uploads/${opts.scope ?? "admin"}/${now.getUTCFullYear()}/${String(
+    now.getUTCMonth() + 1,
+  ).padStart(2, "0")}/${createId()}.${ext}`;
+
+  const cmd = new PutObjectCommand({
+    Bucket: BUCKET,
+    Key: key,
+    ContentType: opts.contentType,
+    ACL: "public-read",
+  });
+
+  const uploadUrl = await getSignedUrl(s3, cmd, { expiresIn: 900 });
+  const endpoint = process.env.S3_PUBLIC_URL ?? "http://localhost:9000";
+
+  return {
+    uploadUrl,
+    publicUrl: `${endpoint}/${BUCKET}/${key}`,
+    key,
+    expiresAt: new Date(Date.now() + 900_000).toISOString(),
+  };
+}
+```
+
+实现说明：
+
+- `expiresIn = 900` 合理，按需求固定 15 分钟。
+- `forcePathStyle: true` 只需要继续保留在 `S3Client` 初始化里；**不需要额外设置 `signableHeaders`**。`Content-Type` 已经通过 `PutObjectCommand` 进入签名。
+- 前端发起 PUT 时**必须显式带上与签名时完全一致的 `Content-Type` header**。缺失或不一致都应让签名校验失败，这是预期行为，不是兼容问题。
+- 不能接受任意 `image/*` 字符串，否则前端传一个奇怪的 subtype 也能拿到 URL。
+- dev 模式（`ENABLE_DEV_LOGIN=true`，本地 `storage/`）继续返回 501，提示走现有代理上传；不要伪造本地 presign。
+
+### 4.5 `GET /admin/users/:id/membership` （D-10）
+
+- `LEFT JOIN memberships`。
+- 不存在 membership 行时 lazy 返回 free 级别：
+  - `level = 'free'`
+  - `status = 'active'`
+  - `expireAt = null`
+  - `benefits = DEFAULT_FREE_BENEFITS`
+  - `avatarQuotaTotal = users.avatarQuota`
+  - `startAt = users.createdAt`
+- `avatarQuotaUsed` = 该用户名下 `pet_avatars.status != 'rejected'` 的数量。
+
+### 4.6 `PUT /admin/users/:id/membership` （D-11）
+
+- body：`{ level, status?, expireAt?, benefits?, avatarQuotaTotal? }`
+- 事务内完成：
+  - `memberships` 按 `user_id` upsert
+  - `users.avatar_quota` 同步更新
+- 校验：
+  - `level`、`status` 必须落在 enum
+  - `expireAt` 允许 `null`
+  - `benefits` 只做结构校验：`[{key,label,value,enabled}]`
+  - `benefits` 缺失时沿用原值，显式传空数组表示清空
+
+### 4.7 `GET /admin/avatar-review/stats` （D-12, UBI-07）
+
+`syncedToDevices` 不要写成 `EXISTS(SELECT ... UNION ALL SELECT ...)`。PostgreSQL 语法上能跑，但既难读又不利于后续改写成 Drizzle/sql 模板。直接拆成两个 `EXISTS ... OR EXISTS ...`。
+
+```sql
+SELECT
+  COUNT(*) FILTER (WHERE pa.status = 'pending')::int AS pending_review,
+  COUNT(*) FILTER (
+    WHERE pa.status IN ('approved', 'processing', 'done')
+  )::int AS approved_total,
+  COUNT(*) FILTER (
+    WHERE pa.status = 'approved'
+      AND (
+        EXISTS (
+          SELECT 1
+          FROM collar_devices cd
+          WHERE cd.pet_id = pa.pet_id
+            AND cd.status = 'online'
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM desktop_pet_bindings b
+          WHERE b.pet_id = pa.pet_id
+            AND b.unbound_at IS NULL
+        )
+      )
+  )::int AS synced_to_devices,
+  COUNT(*) FILTER (
+    WHERE pa.created_at >= date_trunc('day', now())
+  )::int AS today_new_uploads
+FROM pet_avatars pa;
+```
+
+口径说明：
+
+- `approvedTotal` 统计“已通过审核”的总量，因此包含 `approved / processing / done`。
+- `syncedToDevices` 严格按需求，只统计当前 `status = 'approved'` 且宠物存在在线项圈或 active desktop binding 的头像。
+
+### 4.8 shared 类型
+
+shared 只承担“接口契约”的单一职责，不承担 server 内部查询行类型。
+
+```ts
+export type MembershipLevel = "free" | "basic" | "pro" | "premium";
+export type MembershipStatus = "active" | "expired" | "suspended";
+
+export interface MembershipBenefit {
+  key: string;
+  label: string;
+  value: string | number | boolean;
+  enabled: boolean;
+}
+
+export interface Membership {
+  level: MembershipLevel;
+  levelLabel: string;
+  status: MembershipStatus;
+  startAt: string;
+  expireAt: string | null;
+  benefits: MembershipBenefit[];
+  avatarQuotaUsed: number;
+  avatarQuotaTotal: number;
+}
+
+export interface AdminDeviceListItem {
+  type: DeviceType;
+  id: string;
+  name: string;
+  macAddress: string;
+  status: DeviceStatus;
+  claimStatus: DeviceClaimStatus;
+  upgradeStatus: DeviceUpgradeStatus;
+  userId: string | null;
+  userNickname: string | null;
+  petId: string | null;
+  petName: string | null;
+  petSpecies: Species | null;
+  petAvatarUrl: string | null;
+  battery: number | null;
+  signal: number | null;
+  firmwareVersion: string | null;
+  lastOnlineAt: string | null;
+  createdAt: string;
+  hasUploadedAvatar: boolean;
+  avatarProgress: {
+    uploaded: number;
+    total: number;
+  };
+  bindingCount: number;
+}
+
+export interface AdminDeviceDetail { /* 见 §4.2 */ }
+export interface CustomizationTask { /* 见 §4.3 */ }
+export interface AvatarReviewStats {
+  pendingReview: number;
+  approvedTotal: number;
+  syncedToDevices: number;
+  todayNewUploads: number;
+}
+export interface PresignResponse {
+  uploadUrl: string;
+  publicUrl: string;
+  key: string;
+  expiresAt: string;
+}
+```
+
+约束：
+
+- handler 内部仍然可以使用 `typeof table.$inferSelect` 或局部 row type；不要把这些类型再导出到 shared，避免出现“一份 API 类型 + 一份 Drizzle 推导类型”的双源维护。
+- shared 里的类型字段名和接口 JSON 保持一致，不追求与 DB 列一一同名。
+
+### 4.9 shared 常量
+
+```ts
+export const MEMBERSHIP_LEVEL_LABELS: Record<MembershipLevel, string> = {
+  free: "免费用户",
+  basic: "基础会员",
+  pro: "高级会员",
+  premium: "尊享会员",
+};
+
+export const DEFAULT_FREE_BENEFITS: MembershipBenefit[] = [
+  { key: "avatar_quota", label: "形象额度", value: 2, enabled: true },
+  { key: "device_binding", label: "设备绑定", value: "1台", enabled: true },
+  { key: "priority_review", label: "优先审核", value: false, enabled: false },
+];
+```
+
+## 5. 路由注册
+
+`routes/admin/index.ts` 追加：
+
+```ts
+adminRoute.route("/", customizationRoute);
+adminRoute.route("/", membershipsRoute);
+adminRoute.route("/", uploadsRoute);
+// /avatar-review/stats 继续挂在 avatarsRoute 下
+```
+
+兼容性约束：
+
+- 不改现有 `/collars`、`/desktops`、`/avatars` 既有返回结构。
+- 这轮新增到 `routes/admin/devices.ts`、`routes/admin/avatars.ts` 的内容都是新 path 或只读统计，不引入“双写”。
+
+## 6. Seed 脚本（D-13）
+
+`packages/server/scripts/seed-admin-demo.ts` 必须可重复执行，但不能依赖“删 users 自动级联”。
+
+### 6.1 识别种子数据
+
+- 不用 `nickname LIKE '@seed-demo%'` 作为唯一识别条件。昵称是可编辑字段，误伤真实用户的概率不是零。
+- 采用更明确的脚本标识，例如：
+  - `wechatOpenid = 'seed-demo:<n>'`
+  - 或 `email = 'seed-demo+<n>@example.local'`
+- `nickname` 仍然可以保留 `@seed-demo-user-N`，但只作展示，不作主清理键。
+
+### 6.2 清理顺序
+
+按事务手动清理依赖：
+
+1. 找出所有 seed user ids
+2. 找出这些用户名下 `pet ids`
+3. 找出这些宠物名下 `avatar ids`
+4. 删除 `pet_avatar_actions where pet_avatar_id in (...)`
+5. 删除 `pet_avatars where pet_id in (...)`
+6. 删除 `pet_behaviors where pet_id in (...)`
+7. `desktop_pet_bindings` 对 seed 宠物或 seed desktop 置 `unbound_at = now()`
+8. 删除 `memberships where user_id in (...)`
+9. 删除 `device_authorizations` 中 `from_user_id / to_user_id / pet_id` 命中的记录
+10. 删除 seed `collar_devices`
+11. 删除 seed `desktop_devices`
+12. 删除 seed `pets`
+13. 删除 seed `users`
+
+说明：
+
+- 这个顺序与现有 `routes/admin/users.ts`、`routes/admin/pets.ts` 的手工清理策略一致，符合当前 schema 的现实。
+- seed 脚本不创建 `invite_codes`、`messages` 等非本期必需数据，避免把清理范围继续放大。
+
+### 6.3 造数范围
+
+- 20 users
+- 30 pets
+- 25 collars
+- 15 desktops
+- 40 avatars，覆盖 `pending / processing / done / failed / approved / rejected`
+- `done / approved / processing` 的 avatar 插入动作图，数量覆盖 0、部分完成、全部完成
+- 15 memberships，覆盖 4 档和过期状态
+
+## 7. 验证命令
+
+```bash
+pnpm -F shared build
+pnpm -F server build
+pnpm -F server typecheck
+pnpm db:generate
+pnpm db:migrate
+pnpm db:seed:demo
+curl -H "X-Admin-Key: yehey-admin-dev" "http://localhost:9527/api/admin/devices?page=1&pageSize=5"
+curl -H "X-Admin-Key: yehey-admin-dev" "http://localhost:9527/api/admin/customization/tasks?page=1&pageSize=5"
+curl -H "X-Admin-Key: yehey-admin-dev" "http://localhost:9527/api/admin/avatar-review/stats"
+```
+
+## 8. 风险与规避
+
+- **设备统一列表复杂度高**：风险不在 `UNION ALL` 本身，而在 union 前后是否发生行扩张。规避方式是先按设备聚平，再 union。
+- **Drizzle builder 可维护性差**：这类多 CTE、`FILTER`、`EXISTS`、分页复用查询，允许直接写 `sql\`...\``。不要强行炫技。
+- **`avatarProgress` 慢查询**：只要按 `pet_id` 预聚合并 join，一次 SQL 不会形成 N+1；如果写成每行多个相关子查询才会慢。
+- **预签名 PUT 兼容性**：前端最容易漏掉 `Content-Type`。接口文档和实现都必须把“header 必须一致”写死。
+- **旧路由兼容**：现有 `routes/admin/devices.ts`、`routes/admin/avatars.ts` 继续保留原行为；新前端切换期并发调用新旧读接口没有副作用。
+- **benefits jsonb 漂移**：本期只做结构校验，不做 schema versioning；后续若权益项变成报表维度，再拆表。
+
+## 9. 不做
+
+- 不引入 RBAC、不做审计日志。
+- 不做设备编辑/永久删除接口。
+- 不做 benefits 模板 / 会员套餐 CRUD。
+- 不为 admin 搜索额外引入 `pg_trgm`、全文检索或缓存层。

--- a/docs/specs/260417-admin-backend-completion/reflection.md
+++ b/docs/specs/260417-admin-backend-completion/reflection.md
@@ -1,0 +1,101 @@
+# feat/admin-backend-completion 独立反思
+
+基线：`git diff main...HEAD`  
+复核时间：2026-04-18
+
+## 结论
+
+本次复核后，我额外收敛了 2 处问题，分别落在 `scope reduction` 和 `代码质量`：
+
+1. `refactor: trim redundant customization totals`（`df23da6`）
+2. `chore: drop unused presigner dependency`（`1ecc6cc`）
+
+在这两处修正之后，未再发现 D-01..D-16 / UBI-01..UBI-08 的明确漏实现项。当前分支的主要剩余问题不在“是否实现”，而在少数口径仍有歧义，但这些歧义如果现在擅自改，会把实现从“补齐后端”推成“重定义产品语义”。
+
+## 改动了什么，为什么
+
+### 1. 收紧 `/api/admin/customization/tasks` 的返回面
+
+- 修改文件：
+  - `packages/server/src/routes/admin/customization.ts`
+  - `packages/shared/src/types.ts`
+- 改动：
+  - 删除 `CustomizationTask.totalActionTotal`
+  - 删除 `/api/admin/customization/tasks` 顶层的 `baseActionTotal / personalizedActionTotal / totalActionTotal`
+- 为什么：
+  - `requirements.md` 的 D-08 只要求分页壳 `{items,total,page,pageSize}`，以及每条 item 上的 `baseActionTotal / personalizedActionTotal`。
+  - 当前实现额外返回了 `totalActionTotal`，并把三个总数字段同时放在顶层和 item 上，形成了重复 contract。
+  - 全仓检索后没有任何 consumer 使用这些额外字段；继续保留只会扩大 shared contract，增加前后端后续兼容负担。
+- 判断：
+  - 这是典型的 scope creep，不是功能缺失。
+  - 去掉后，前端仍可用 `baseActionTotal + personalizedActionTotal` 算出总动作数，不影响 D-07/D-08/UBI-01。
+
+### 2. 删除已经失效的 `@aws-sdk/s3-request-presigner` 依赖
+
+- 修改文件：
+  - `packages/server/package.json`
+  - `pnpm-lock.yaml`
+- 改动：
+  - 删除 `@aws-sdk/s3-request-presigner`
+- 为什么：
+  - 当前 `packages/server/src/utils/storage.ts` 已经改为直接用 `SignatureV4 + HttpRequest` 生成预签名 PUT URL。
+  - 全仓不存在 `@aws-sdk/s3-request-presigner` 的调用点；继续保留只是死依赖。
+  - 这类残留依赖会让实现思路和依赖图失真，也会把 lockfile 带得更重。
+- 判断：
+  - 这是代码质量问题，不涉及功能变更。
+
+## 什么没改，为什么
+
+### 1. 多 active binding 的 desktop，列表展示字段仍按“代表宠物”口径返回
+
+- 涉及文件：
+  - `packages/server/src/routes/admin/devices.ts`
+- 现状：
+  - `species` / `imageStatus` 筛选已经按全部 active bindings 做 `EXISTS`。
+  - 但列表行里的 `petId / petName / petSpecies / petAvatarUrl / hasUploadedAvatar / avatarProgress` 仍然跟随“代表宠物”。
+- 为什么没改：
+  - 这里真正缺的是产品口径，而不是 SQL 技巧。
+  - 对多宠物 desktop，`avatarProgress` 应按代表宠物、按并集、按最大值还是按最近绑定计算，`requirements.md` 没定义。
+  - 现在直接改，很容易把“修 bug”做成“偷偷重写 contract”。
+- 结论：
+  - 保留现状，但这个点应在下一轮先补口径，再改实现。
+
+### 2. `publicUrl` 在本地 MinIO 环境的可访问性问题未处理
+
+- 涉及文件：
+  - `packages/server/src/utils/storage.ts`
+- 现状：
+  - 预签名 PUT 已满足 `Content-Type` 绑定与 15 分钟过期要求。
+  - 但 `publicUrl` 是否能匿名 GET，仍依赖对象存储 ACL / bucket policy。
+- 为什么没改：
+  - 如果在服务端自动改 bucket policy，会把这次后端补齐变成基础设施策略变更。
+  - 如果把 `publicUrl` 改成 signed GET URL，则会直接改变接口契约。
+  - 这两种做法都超出本次“补齐 admin backend”的安全改动范围。
+- 结论：
+  - 继续保留现有 contract，把它视为部署环境配置问题，而不是在本轮顺手扩 scope。
+
+## 对三个维度的最终判断
+
+### 代码质量
+
+- 已修正的两个点都属于“实现能跑，但不够干净”的问题：
+  - 一个是冗余返回字段
+  - 一个是残留依赖
+- 其余实现虽有一些辅助函数重复，但还没有到需要额外抽象的程度；强行继续抽公共层，收益不高。
+
+### 架构合理性
+
+- `shared` 仍然主要承担 API contract，server 内部 row type 没有继续外溢，这个边界是对的。
+- 新接口都挂在 `/api/admin/*` 并走现有 `X-Admin-Key` 中间件，没有破坏老 `/collars`、`/desktops`、`/avatars` 的兼容性，这一点也成立。
+- 真正还不够稳的是 desktop 多绑定场景下的展示语义，而不是模块拆分本身。
+
+### Scope reduction
+
+- 本轮新增实现里，最明确的超需求项就是 `customization/tasks` 的冗余 totals，我已经删掉。
+- 其余新增接口与 shared 类型，经过逐条对照，没有再发现明显超出 D-01..D-16 的新功能。
+- 也没有发现新的未覆盖 requirement；当前更多是“边界口径待澄清”，不是“功能没做”。
+
+## 验证
+
+- `pnpm --filter shared build`
+- `pnpm --filter server typecheck`

--- a/docs/specs/260417-admin-backend-completion/requirements.md
+++ b/docs/specs/260417-admin-backend-completion/requirements.md
@@ -1,0 +1,88 @@
+# 后端补齐：设备管理 / 定制中心 / 用户会员 / 图像审核
+
+日期：2026-04-17
+负责人：@so2liu
+
+## 1. 背景
+
+管理后台前端页面已经落地，但多处关键字段由前端在本地"拼凑/猜测/硬编码"。本轮补齐后端接口、DB 表、共享类型，让前端彻底去 demo 化。对应前端问题点参考 PR 描述（Devices.tsx L552-749、Customization.tsx L397-633、Users.tsx L348-513、ImageReview.tsx L406-453）。
+
+## 2. 范围
+
+### 2.1 In scope
+
+- 新增 `memberships` 表 + 完整会员读写接口
+- 统一设备列表 `GET /api/admin/devices`（扁平合并 + type 字段 + 服务端搜索/筛选/分页）
+- 设备详情 `GET /api/admin/devices/:type/:id/detail`
+- 定制中心任务列表 `GET /api/admin/customization/tasks`（带摘要字段）
+- 图像预签名上传 `POST /api/admin/uploads/presign`
+- 会员读写 `GET/PUT /api/admin/users/:id/membership`
+- 图像审核统计 `GET /api/admin/avatar-review/stats`
+- seed 测试数据脚本
+- `packages/shared` 相关类型同步
+
+### 2.2 Out of scope
+
+- 会员计费 / 支付流转
+- 管理员编辑设备 / 永久删除设备（按钮保留禁用态）
+- 小程序端会员展示
+- 动作类别（基础/个性化）配置管理 UI —— 本轮用静态常量即可
+- 鉴权体系重构（沿用现有 `X-Admin-Key`）
+
+## 3. 关键决策
+
+- **D-01** 会员数据模型：新增独立 `memberships` 表，与 `users` 一对一（`userId` unique FK），`benefits` 字段用 `jsonb` 存储权益数组。**Why**：后续权益结构会膨胀；用 jsonb 避免频繁迁移。**How to apply**：users 表不加字段；读取会员时 LEFT JOIN，缺失记录时按 `free` 级别 lazy 返回默认值。
+
+- **D-02** 会员等级枚举：`free | basic | pro | premium`，定义在 PG enum `membership_level`。**Why**：枚举值稳定、前端可映射。**How to apply**：`avatarQuota` 仍保留在 users（是额度字段），但"等级"由 `memberships.level` 决定，不再由 quota 反推。
+
+- **D-03** 上传方案：预签名 PUT URL。后端签发 MinIO 预签名 URL（含 15 min 过期、强制 Content-Type 白名单 image/*、key 前缀 `uploads/admin/YYYY/MM/<id>.<ext>`），返回 `{uploadUrl, publicUrl, key, expiresAt}`。**Why**：省服务端带宽，接口契约里已注明。**How to apply**：`routes/upload.ts` 的代理上传不删，留着给小程序端；admin 只用预签名。
+
+- **D-04** 统一设备列表形状：扁平合并 `{items:[{type:'collar'|'desktop', id, name, macAddress, status, claimStatus, upgradeStatus, userId, userNickname, petId?, petName?, petSpecies?, petAvatarUrl?, battery?, signal?, lastOnlineAt, createdAt, hasUploadedAvatar, avatarProgress:{uploaded,total}, bindingCount}], total, page, pageSize}`。**Why**：前端一套分页/筛选/排序；跨类型搜索和绑定状态筛选能工作。**How to apply**：SQL 用 `collars UNION ALL desktops` 做子查询，再外层 JOIN users/pets/avatar 聚合。分页在合并后做。
+
+- **D-05** 列表筛选参数：`keyword`（name/mac/userNickname 模糊）、`type`（collar|desktop|all）、`model`（预留字符串，先按 name 前缀匹配）、`imageStatus`（uploaded|pending|all，以 `petAvatars.status IN ('approved','done')` 判定）、`bindingStatus`（bound|unbound）、`species`（cat|dog|all）、`status`（online|offline|pairing|all）、`sort`（createdAt|lastOnlineAt）、`order`（asc|desc）、`page`（默认 1）、`pageSize`（默认 20，最大 100）。
+
+- **D-06** 设备详情 `/devices/:type/:id/detail` 返回：基础字段 + 真实绑定宠物（含 `petAvatarUrl`、`speciesLabel`、陪伴天数 = `now - bindings.createdAt`）+ 关联设备（同一 `pet.userId` 下的其他设备，type 不同优先）+ 定制进度 `{total, uploaded, approved, pending}` + 最后同步时间 + 激活时间（用 `createdAt` 代替）。**Why**：前端目前这些都在猜。**How to apply**：陪伴天数按 collar 看 `collarDevices.petId` 的 binding，desktop 看 `desktopPetBindings`。
+
+- **D-07** 定制进度口径：基础动作清单由 `ACTION_CATALOG` 常量（server/src/constants/actions.ts）定义，固定 18 项分为 `base`(N 条) 与 `personalized`(M 条)。**Why**：前端现在假设 18 项总数，需要统一来源。**How to apply**：新建常量文件，导出 `BASE_ACTIONS[]`、`PERSONALIZED_ACTIONS[]`；所有进度计算都 JOIN `petAvatarActions.actionType` 比对。
+
+- **D-08** `GET /api/admin/customization/tasks` 返回左侧列表所需摘要：`{items:[{avatarId, petId, petName, petSpecies, userId, userNickname, status, defaultPreviewUrl, baseActionCount, personalizedActionCount, totalActionCount, baseActionTotal, personalizedActionTotal, categoryStatus:'empty'|'partial'|'base_done'|'all_done', isNewToday, createdAt, reviewedAt}], total, page, pageSize}`。支持 `keyword`（user/pet 名）、`status`、`category`（base|personalized|all）、`page`、`pageSize`。
+
+- **D-09** `defaultPreviewUrl` 选取规则：优先取 `petAvatars.sourceImageUrl`；若为空取第一条 `petAvatarActions.imageUrl`（按 sortOrder）。
+
+- **D-10** `GET /api/admin/users/:id/membership` 返回：`{level, levelLabel, status:'active'|'expired'|'suspended', startAt, expireAt, benefits:[{key,label,value,enabled}], avatarQuotaUsed, avatarQuotaTotal}`。缺失记录时 lazy 返回 `{level:'free', status:'active', expireAt:null, benefits:DEFAULT_FREE_BENEFITS, avatarQuotaTotal:users.avatarQuota}`。
+
+- **D-11** `PUT /api/admin/users/:id/membership` 入参：`{level, expireAt, status, benefits[], avatarQuotaTotal}`。首次写入时 upsert；`avatarQuotaTotal` 同步写到 `users.avatarQuota`（保持小程序端一致）。
+
+- **D-12** `GET /api/admin/avatar-review/stats` 返回：`{pendingReview, approvedTotal, syncedToDevices, todayNewUploads}`。`syncedToDevices` 口径：存在 `petAvatars.status='approved'` 且该 pet 至少有一台 `collarDevices.status='online'` 或 `desktopPetBindings` 关联。**Why**：前端现状是按 avatar 状态算，不准。**How to apply**：用 EXISTS 子查询避免 N+1。
+
+- **D-13** seed 脚本：`packages/server/scripts/seed-admin-demo.ts`，可重复执行（先清理 `@seed-demo` 前缀数据），生成 ~20 用户、~30 宠物、~25 collars、~15 desktops、~40 avatars（各状态都有）、若干 actions、若干 memberships（覆盖 4 档）。**How to apply**：pnpm script `db:seed:demo`。
+
+- **D-14** 鉴权：所有新路由继续用 `middleware/admin.ts`（`X-Admin-Key`）。本期不做 RBAC。
+
+- **D-15** shared 类型：在 `packages/shared/src/types.ts` 新增 `Membership`、`MembershipLevel`、`AdminDeviceListItem`、`AdminDeviceDetail`、`CustomizationTask`、`AvatarReviewStats`、`PresignResponse`。前后端共用。
+
+- **D-16** 分页 helper：在 `packages/server/src/utils/pagination.ts` 新建 `parsePagination(c)` + `buildPageResponse(items, total, params)`，统一 `{items, total, page, pageSize}` 形状。**Why**：当前路由 adhoc 写分页，需要收敛。**How to apply**：8 个新接口中的 3 个列表类接口都走它。
+
+## 4. 验收（EARS）
+
+- **UBI-01** WHILE 管理员访问定制中心左侧列表，WHEN 调用 `/admin/customization/tasks`，系统 SHALL 返回每条任务的真实 `baseActionCount / personalizedActionCount / categoryStatus / defaultPreviewUrl`，前端 **不得** 再 fallback demo 数据。
+
+- **UBI-02** WHILE 管理员访问设备详情，WHEN 调用 `/admin/devices/:type/:id/detail`，系统 SHALL 返回真实绑定宠物、宠物头像 URL、陪伴天数、关联设备列表、定制进度 `{uploaded,total,approved,pending}`，前端 **不得** 再按 userId 猜。
+
+- **UBI-03** WHEN 管理员在设备列表搜索关键字 "布丁"，系统 SHALL 服务端匹配 name/macAddress/userNickname 并返回跨 collar/desktop 的合并结果，`total` 等于真实命中数。
+
+- **UBI-04** WHEN 管理员保存会员配置，系统 SHALL upsert `memberships` 行、同步 `users.avatarQuota`，并在随后 `GET /membership` 返回一致数据。
+
+- **UBI-05** WHEN 前端请求预签名上传，系统 SHALL 返回 15 分钟内有效的 PUT URL，URL 对非 `image/*` Content-Type 上传 SHALL 拒绝。
+
+- **UBI-06** WHEN 执行 `pnpm db:seed:demo`，系统 SHALL 生成覆盖 4 档会员/各 avatar 状态/绑定与未绑定设备的数据集，重复执行不产生重复。
+
+- **UBI-07** WHEN 请求 `/admin/avatar-review/stats`，`syncedToDevices` SHALL 按"avatar approved 且 pet 有在线设备或桌面端绑定"口径返回，不是按 avatar 状态字段简单计数。
+
+- **UBI-08** 所有新接口 SHALL 在缺少 `X-Admin-Key` 或值不匹配时返回 401。
+
+## 5. 非目标
+
+- 不改动现有 `/collars`、`/desktops`、`/avatars` 老接口行为（保持向后兼容，前端按需切换到新接口）。
+- 不引入 Redis / 缓存层。
+- 不做接口级限流。

--- a/docs/specs/260417-admin-backend-completion/review-final.md
+++ b/docs/specs/260417-admin-backend-completion/review-final.md
@@ -1,0 +1,95 @@
+# 最终审查结论
+
+分支：`feat/admin-backend-completion`
+审查基线：`git diff main...HEAD`
+审查范围：按需求文档与本次 review 要点，对 admin 新增后端接口做 bug / 安全 / 性能 / 逻辑正确性硬审查。
+
+## 已修问题
+
+### 1. P0: admin 预签名 PUT 没有把 `Content-Type` 绑进签名
+
+- 文件：`packages/server/src/utils/storage.ts`
+- 风险：原实现返回的 URL 只有 `X-Amz-SignedHeaders=host`，`Content-Type` 没进入签名；实际验证里，用 `text/plain` 也能成功 PUT，白名单约束形同虚设。
+- 修复：
+  - 改为用底层 SigV4 直接签 `HttpRequest`
+  - 将 `content-type` 放入 `SignedHeaders`
+  - 用同一个 `signingDate` 计算 `expiresAt`，避免响应时间和签名时间漂移
+  - 补充 server 直接依赖：`@smithy/hash-node`、`@smithy/protocol-http`、`@smithy/signature-v4`
+- commit：`574c692 fix: bind admin upload content type in presign`
+- 验证：
+  - `/api/admin/uploads/presign` 返回 `X-Amz-SignedHeaders=content-type;host`
+  - 错误 `Content-Type` 上传返回 `403`
+  - 正确 `Content-Type` 上传返回 `200`
+
+### 2. P1: membership benefits 可写入脏数据
+
+- 文件：`packages/server/src/routes/admin/memberships.ts`
+- 风险：原实现只校验字段 shape，允许重复 `key`、空白 `key/label`、非有限数字；实测重复 key payload 会被 200 接受，后续前端按 key 渲染/覆盖时会出现不确定行为。
+- 修复：
+  - 要求 `key` / `label` trim 后非空
+  - 拒绝重复 `key`
+  - 拒绝 `NaN` / `Infinity`
+- commit：`3c4bdb9 fix: reject invalid membership benefits payloads`
+- 验证：
+  - 带重复 `benefits[].key` 的 `PUT /api/admin/users/:id/membership` 现在返回 `400`
+
+### 3. P1: customization 动作进度按行数计数，遇到重复 action 会虚高
+
+- 文件：`packages/server/src/routes/admin/customization.ts`
+- 风险：`base_action_count` / `personalized_action_count` 原本按 `COUNT(*)` 统计；一旦同一 `pet_avatar_id + action_type` 出现重复记录，任务进度会被放大，`categoryStatus` 也会被错误推进到 `base_done` / `all_done`。
+- 修复：
+  - 改成 `COUNT(DISTINCT paa.action_type)`，按动作类型去重
+- commit：`9d304be fix: dedupe customization action progress counts`
+
+### 4. P1: demo seed 重跑会累积旧的 desktop bindings
+
+- 文件：`packages/server/scripts/seed-admin-demo.ts`
+- 风险：原清理逻辑只是把命中的 `desktop_pet_bindings` 软解绑，不删除历史行；重复执行 seed 会不断堆积旧绑定记录，不满足“可重复执行不产生重复”。
+- 修复：
+  - 清理阶段改为直接删除命中的 `desktop_pet_bindings`
+- commit：`b21c7b9 fix: delete stale seed desktop bindings on reseed`
+- 验证：
+  - 连续两次执行 `pnpm --filter server db:seed:demo`
+  - 关联 seed 数据的 `desktop_pet_bindings` 计数稳定为 `19`，不再递增
+
+## 已核对通过
+
+- SQL 注入：
+  - `keyword`、`status` 逗号分隔等动态值都走参数插值
+  - `sort` / `order` 先白名单校验，再拼固定列名/方向，未发现可注入入口
+- 慢查询 / N+1：
+  - `devices` 和 `customization/tasks` 都是单 SQL + CTE 预聚合，不存在逐行补查
+  - `devices` 的 `count` 与分页查询分开执行，避免把总数统计塞进每一页
+- 事务边界：
+  - `PUT /users/:id/membership` 的 `users.avatarQuota` 更新和 `memberships` upsert 在同一事务中，原子性满足要求
+- 401 覆盖：
+  - 新路由都挂在 `/api/admin/*` 下，经过 `adminMiddleware`
+  - 实测无 `X-Admin-Key` 请求 `/api/admin/devices` 返回 `401`
+- shared 契约：
+  - `AdminDeviceListItem` / `CustomizationTask` / `Membership` 等新增 contract，handler 返回字段已覆盖
+- 老接口兼容：
+  - `/api/admin/collars`、`/api/admin/desktops`、`/api/admin/avatars` 既有路径和结构未被改写，本轮只追加新路由/只读统计
+
+## 剩余未修项
+
+### 1. `publicUrl` 在当前本地 MinIO 环境下仍然返回 403
+
+- 现象：预签名 PUT 成功后，直接 GET 返回的 `publicUrl`，当前环境得到 `403`
+- 判断：这更像对象存储暴露策略 / bucket policy 问题，不是本次签名修复本身的问题；现有 `uploadFile()` 也沿用同样的公开 URL 口径
+- 处理：本轮未改接口契约，也未把返回值切成 signed GET URL，避免超 scope
+
+### 2. 多 active binding 的 desktop，列表里的 `hasUploadedAvatar/avatarProgress` 仍然按代表宠物口径返回
+
+- 现状：`imageStatus` / `species` 过滤已经对 desktop 的全部 active bindings 做 `EXISTS`，但列表行上的 `hasUploadedAvatar` 和 `avatarProgress` 仍来自代表宠物
+- 风险：极端情况下，过滤命中和列表展示字段可能出现口径差异
+- 原因：需求没有明确定义“多宠物 desktop 的进度字段应按代表宠物、按并集还是按最大值聚合”
+- 处理：本轮未擅自重定义该字段语义，建议下一轮先补清口径再改 SQL
+
+## 本轮验证
+
+- `pnpm --filter server typecheck`
+- 重启 server 后验证 `/api/admin/uploads/presign`
+- 验证错误 `Content-Type` 上传 `403`、正确 `Content-Type` 上传 `200`
+- 验证重复 `benefits.key` 的 membership PUT 返回 `400`
+- 验证 `/api/admin/customization/tasks?pageSize=2` 正常返回
+- 连续两次执行 `pnpm --filter server db:seed:demo`，确认 desktop binding 计数稳定

--- a/docs/specs/260417-admin-backend-completion/review.md
+++ b/docs/specs/260417-admin-backend-completion/review.md
@@ -1,0 +1,75 @@
+# 设计审查结论
+
+本次审查只做防御性修正，没有扩 scope、没有引入新功能。`design.md` 已按下面结论直接修改。
+
+## 问题清单
+
+### P0
+
+1. `GET /admin/devices` 原方案“先 `UNION ALL`，再外层 JOIN 聚合”会把 desktop 多绑定、pet 多 avatar 的行数放大，导致 `items` 去重困难、`total` 失真、分页不稳定。这个不是优化问题，是结果正确性问题。
+2. 预签名 PUT 原方案把白名单写成泛化的 `image/*`，同时没把“前端 PUT 必须显式带同一 `Content-Type`”写死。这样要么白名单约束不成立，要么线上会出现签名不匹配。
+
+### P1
+
+3. `avatarProgress` 如果在 devices 列表里按行跑多个相关子查询，不会形成经典 N+1 HTTP/DB 往返，但会退化成 SQL 级“每行反复算一遍”的慢查询。必须先按 `pet_id` 预聚合。
+4. `customization/tasks` 的 `categoryStatus` 和 `category` 语义原先不自洽。特别是 `personalized > 0 && base = 0` 的数据会落入灰区，`category=base` 还会把已进入 personalized 阶段的任务错误排除。
+5. `/avatar-review/stats` 里的 `EXISTS (SELECT ... UNION ALL SELECT ...)` 在 PostgreSQL 里可以跑，但写法晦涩，后续改成 Drizzle/sql 模板很难维护。这里没有必要耍花活，直接两个 `EXISTS ... OR EXISTS ...`。
+6. seed 脚本“可重复执行”的删除策略原先只写 `nickname LIKE '@seed-demo%'`，风险有两个：
+   - 误伤真实用户
+   - 当前 schema 大量依赖应用层手动清理，不存在完整 FK 级联，单删 user 不够
+7. 设备详情原方案拿 `collar.updatedAt` 推 `companionDays`，还发明了 `pet code`。前者没有数据依据，后者是需求外字段。
+
+### P2
+
+8. `memberships.benefits` 用 `jsonb` 本身没问题，但只能当“配置快照”存，不适合这轮拿来做查询维度。否则后面会同时踩业务校验、索引和迁移三类坑。
+9. shared 类型和 server 里的 Drizzle inferred type 如果都拿来表示同一份 API 契约，会出现双源维护。shared 应该只承担接口 contract，Drizzle 类型留在 handler 内部。
+10. 对现有 `routes/admin/devices.ts`、`routes/admin/avatars.ts` 的“无破坏性”假设基本成立，但前提是只新增 path / 只读统计，不去改老接口 payload。新旧前端切换期并发读没有双写风险。
+
+## 修复摘要
+
+`design.md` 已直接收紧为下面这版实现口径：
+
+1. `memberships`
+   - 保留 `user_id` 唯一约束和 `users -> memberships` 级联删除。
+   - 明确 `benefits` 是 `jsonb` 整包替换，不做 patch merge，不做 JSON 子字段查询。
+   - 明确不能把这一个级联误当成全库都具备 FK 级联。
+
+2. `GET /admin/devices`
+   - 改成“先按设备聚平成一行，再 `UNION ALL`”。
+   - 明确 desktop 只选一个代表宠物做扁平字段展示，但 `species` / `imageStatus` 过滤必须对全部 active bindings 做 `EXISTS`。
+   - 明确允许用 `db.execute(sql\`...\`)` 写 CTE，不强求 Drizzle builder。
+   - 明确 `page` 查询和 `count` 查询分开执行，并补稳定二级排序。
+
+3. 预签名 PUT URL
+   - 白名单收紧为 `image/jpeg | image/png | image/webp`。
+   - 明确 `expiresIn = 900`。
+   - 明确 MinIO `forcePathStyle` 保留在 `S3Client` 即可，不需要额外 `signableHeaders`。
+   - 明确前端 PUT 必须带和签名完全一致的 `Content-Type` header。
+
+4. `customization/tasks`
+   - 重新定义 `categoryStatus`，保证所有组合都能落类。
+   - 把 `category` 解释成“关注哪一类动作”，不是“纯 base / 纯 personalized 的互斥筛选”。
+   - `defaultPreviewUrl` 改为先读 `NULLIF(source_image_url, '')`，再 fallback action 图。
+
+5. `/avatar-review/stats`
+   - `syncedToDevices` 改成两个 `EXISTS ... OR EXISTS ...`。
+   - 明确 `approvedTotal` 统计“已通过审核”的头像总数，包含 `approved / processing / done`。
+
+6. shared vs server 类型
+   - 明确 shared 是 API contract 单一来源。
+   - Drizzle inferred type 只在 server 内部查询行映射时使用，不向 shared 外溢。
+
+7. seed
+   - 不再只用 `nickname LIKE` 识别数据。
+   - 改成用更明确的 marker 字段定位 seed user。
+   - 明确手工清理顺序：`pet_avatar_actions -> pet_avatars -> pet_behaviors -> bindings/device_authorizations/memberships -> devices -> pets -> users`。
+
+8. 向后兼容
+   - 明确老 `/collars`、`/desktops`、`/avatars` 行为不改。
+   - 新增接口集中在新 path 和只读统计，避免切换期双写。
+
+## 剩余待决项
+
+1. `approvedTotal` 的展示文案需要和前端对齐。现在设计按“已通过审核总量”统计 `approved / processing / done`；如果前端字面上只想看当前 `status = 'approved'`，名称要一起调整，否则会误读。
+2. `companionDays` 对项圈只能是近似值，因为 schema 没有绑定历史。若产品坚持要精确值，只能补新表或补事件记录，这超出本轮范围。
+3. `keyword ILIKE '%xx%'` 仍然会扫表。admin 数据量如果很快上万，后续要单独评估 `pg_trgm`；这轮不建议顺手引入。

--- a/docs/specs/260417-admin-backend-completion/tasks.md
+++ b/docs/specs/260417-admin-backend-completion/tasks.md
@@ -1,0 +1,82 @@
+# 任务拆分
+
+5 个垂直切片，每个任务完成后都可独立 lint/build/typecheck。
+
+- [ ] **1. 基础设施：memberships 表 + 索引 + 分页工具 + shared 类型与常量**
+  - **文件**：
+    - `packages/server/src/db/schema.ts`（新增 membershipLevelEnum、membershipStatusEnum、memberships 表；并补 §2.2 所列索引）
+    - `packages/server/src/utils/pagination.ts`（新建）
+    - `packages/shared/src/types.ts`（新增 Membership、MembershipLevel、MembershipStatus、MembershipBenefit、AdminDeviceListItem、AdminDeviceDetail、CustomizationTask、AvatarReviewStats、PresignResponse）
+    - `packages/shared/src/constants.ts`（新增 MEMBERSHIP_LEVEL_LABELS、DEFAULT_FREE_BENEFITS）
+    - `packages/server/drizzle/`（`pnpm db:generate` 产生的迁移 SQL）
+  - **做什么**：按 design §2 / §3 / §4.8 / §4.9 的定义落地数据库结构和共享契约，为后续接口提供底座。shared 类型保持"API 契约单一来源"定位，不外溢 Drizzle inferred type。
+  - **完成标准**：
+    - `pnpm -F shared build` 通过
+    - `pnpm -F server typecheck` 通过
+    - `pnpm db:generate` 产出迁移文件，本地 `pnpm db:migrate` 执行成功
+    - `psql` 查表 `memberships` 存在，有 `uq_memberships_user_id` 唯一约束，有 ON DELETE CASCADE
+  - **关联决策**：D-01、D-02、D-15、D-16
+
+- [ ] **2. 上传预签名 + 会员接口（两个小模块合并提交）**
+  - **文件**：
+    - `packages/server/src/utils/storage.ts`（新增 `createPresignedPutUrl`）
+    - `packages/server/package.json`（新增依赖 `@aws-sdk/s3-request-presigner`）
+    - `packages/server/src/routes/admin/uploads.ts`（新建，`POST /admin/uploads/presign`）
+    - `packages/server/src/routes/admin/memberships.ts`（新建，`GET /admin/users/:id/membership`、`PUT /admin/users/:id/membership`）
+    - `packages/server/src/routes/admin/index.ts`（注册两个新路由）
+  - **做什么**：实现 §4.4、§4.5、§4.6。预签名严格白名单 `image/jpeg|png|webp`，dev 模式（`ENABLE_DEV_LOGIN=true`）返回 501。membership GET lazy 返回 free；PUT 事务内 upsert + 同步 `users.avatarQuota`。
+  - **完成标准**：
+    - `pnpm -F server build` 通过
+    - 手测：
+      - `curl -X POST -H "X-Admin-Key: yehey-admin-dev" -H "Content-Type: application/json" -d '{"contentType":"image/jpeg"}' http://localhost:9527/api/admin/uploads/presign` 返回 `uploadUrl`
+      - 对返回的 uploadUrl 做 `curl -X PUT -H "Content-Type: image/jpeg" --data-binary @/some.jpg` 成功 200
+      - 读/写 `/admin/users/:id/membership` 结果一致，`avatarQuotaTotal` 回写到 users 表
+      - 缺 `X-Admin-Key` 时 401
+  - **关联决策**：D-03、D-10、D-11、D-14
+
+- [ ] **3. 统一设备列表 + 设备详情**
+  - **文件**：
+    - `packages/server/src/routes/admin/devices.ts`（在既有文件追加两个 handler，老 `/collars`/`/desktops` 不改）
+  - **做什么**：实现 §4.1（`GET /admin/devices`）、§4.2（`GET /admin/devices/:type/:id/detail`）。接受直接用 `db.execute(sql\`...\`)` 写 CTE，不强求 Drizzle builder。`page` 查询和 `count` 查询分开执行，二级排序补 `type asc, id desc`。desktop 的 `species/imageStatus` 筛选必须对全部 active bindings 做 EXISTS。
+  - **完成标准**：
+    - `pnpm -F server typecheck` 通过
+    - 手测：
+      - `/admin/devices?page=1&pageSize=5` 扁平返回 `{items,total,page,pageSize}`，items 含 `type` 字段
+      - `keyword=布丁` 跨 collar/desktop 命中
+      - `bindingStatus=unbound` 只返回无绑定的
+      - `/admin/devices/collar/:id/detail`、`/admin/devices/desktop/:id/detail` 返回 design §4.2 全部字段
+      - `avatarProgress` 数字与 DB 实际 `pet_avatar_actions` 对得上
+  - **关联决策**：D-04、D-05、D-06
+
+- [ ] **4. 定制任务列表 + 图像审核统计**
+  - **文件**：
+    - `packages/server/src/routes/admin/customization.ts`（新建）
+    - `packages/server/src/routes/admin/avatars.ts`（追加 `GET /avatar-review/stats`）
+    - `packages/server/src/routes/admin/index.ts`（注册 customization）
+  - **做什么**：实现 §4.3（`GET /admin/customization/tasks`）和 §4.7（`GET /admin/avatar-review/stats`）。动作计数用 `COUNT(*) FILTER` 做一次聚合；`defaultPreviewUrl` 先 `NULLIF(source_image_url,'')` 再 fallback action。`categoryStatus` 按 §4.3 五状态映射（empty/all_done/base_done/partial）。stats 里 `approvedTotal` 包含 `approved/processing/done`。
+  - **完成标准**：
+    - `pnpm -F server typecheck` 通过
+    - 手测：
+      - `/admin/customization/tasks?page=1&pageSize=5` 返回 `{items,total,page,pageSize,baseActionTotal:6,personalizedActionTotal:8,totalActionTotal:14}` 或把三个总数放在每条 item 上
+      - `category=base` 返回 baseActionCount>0 的任务
+      - `/admin/avatar-review/stats` 四个数合理（与手工 SQL 对得上）
+  - **关联决策**：D-07、D-08、D-09、D-12
+
+- [ ] **5. Seed 脚本 + npm script**
+  - **文件**：
+    - `packages/server/scripts/seed-admin-demo.ts`（新建）
+    - `packages/server/package.json`（新增 `"db:seed:demo": "bun scripts/seed-admin-demo.ts"`）
+    - 根 `package.json` 加 workspace 转发脚本（如当前惯例使用 `pnpm -F server db:seed:demo` 则不需）
+  - **做什么**：按 design §6 造 20 users / 30 pets / 25 collars / 15 desktops / 40 avatars / 各档 memberships。使用 `wechatOpenid='seed-demo:<n>'` 做主清理键。清理顺序严格按 §6.2。
+  - **完成标准**：
+    - `pnpm -F server db:seed:demo` 执行成功
+    - 连续执行两次不产生重复数据（不报唯一约束冲突）
+    - `SELECT count(*) FROM users WHERE wechat_openid LIKE 'seed-demo:%'` = 20
+    - `/admin/devices?page=1&pageSize=20` 返回真实 items，不再需要 demo fallback
+  - **关联决策**：D-13
+
+## 任务间依赖
+
+- 1 → 2,3,4：1 提供 schema + shared 类型，后续任务都依赖
+- 2,3,4 互相独立，可任意顺序
+- 5 依赖 1（需要 memberships 表）和 2（需要读写能力验证）

--- a/packages/server/drizzle/0008_empty_sharon_carter.sql
+++ b/packages/server/drizzle/0008_empty_sharon_carter.sql
@@ -1,0 +1,21 @@
+CREATE TYPE "public"."membership_level" AS ENUM('free', 'basic', 'pro', 'premium');--> statement-breakpoint
+CREATE TYPE "public"."membership_status" AS ENUM('active', 'expired', 'suspended');--> statement-breakpoint
+CREATE TABLE "memberships" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"level" "membership_level" DEFAULT 'free' NOT NULL,
+	"status" "membership_status" DEFAULT 'active' NOT NULL,
+	"start_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expire_at" timestamp with time zone,
+	"benefits" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "memberships" ADD CONSTRAINT "memberships_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_memberships_user_id" ON "memberships" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_collar_devices_pet_id" ON "collar_devices" USING btree ("pet_id");--> statement-breakpoint
+CREATE INDEX "idx_desktop_pet_bindings_device_created_at" ON "desktop_pet_bindings" USING btree ("desktop_device_id","created_at" desc) WHERE "desktop_pet_bindings"."unbound_at" is null;--> statement-breakpoint
+CREATE INDEX "idx_desktop_pet_bindings_pet_id" ON "desktop_pet_bindings" USING btree ("pet_id") WHERE "desktop_pet_bindings"."unbound_at" is null;--> statement-breakpoint
+CREATE INDEX "idx_pet_avatar_actions_avatar_sort_order" ON "pet_avatar_actions" USING btree ("pet_avatar_id","sort_order","id");--> statement-breakpoint
+CREATE INDEX "idx_pet_avatars_pet_created_at" ON "pet_avatars" USING btree ("pet_id","created_at" desc);

--- a/packages/server/drizzle/meta/0008_snapshot.json
+++ b/packages/server/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1627 @@
+{
+  "id": "139fbd11-479a-48d4-8c72-9206d01e615b",
+  "prevId": "0fad1e01-2b8f-4177-b355-63c1d045a7e2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.behavior_schedule_blocks": {
+      "name": "behavior_schedule_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_minutes": {
+          "name": "start_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_minutes": {
+          "name": "end_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "behavior_schedule_blocks_schedule_id_behavior_schedules_id_fk": {
+          "name": "behavior_schedule_blocks_schedule_id_behavior_schedules_id_fk",
+          "tableFrom": "behavior_schedule_blocks",
+          "tableTo": "behavior_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "behavior_schedule_blocks_start_minutes_check": {
+          "name": "behavior_schedule_blocks_start_minutes_check",
+          "value": "\"behavior_schedule_blocks\".\"start_minutes\" >= 0 AND \"behavior_schedule_blocks\".\"start_minutes\" < 1440"
+        },
+        "behavior_schedule_blocks_end_minutes_check": {
+          "name": "behavior_schedule_blocks_end_minutes_check",
+          "value": "\"behavior_schedule_blocks\".\"end_minutes\" > 0 AND \"behavior_schedule_blocks\".\"end_minutes\" <= 1440"
+        },
+        "behavior_schedule_blocks_range_check": {
+          "name": "behavior_schedule_blocks_range_check",
+          "value": "\"behavior_schedule_blocks\".\"start_minutes\" < \"behavior_schedule_blocks\".\"end_minutes\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.behavior_schedules": {
+      "name": "behavior_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_type": {
+          "name": "effective_type",
+          "type": "schedule_effective_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'everyday'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "behavior_schedules_active_unique": {
+          "name": "behavior_schedules_active_unique",
+          "columns": [
+            {
+              "expression": "species",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"behavior_schedules\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collar_devices": {
+      "name": "collar_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mac_address": {
+          "name": "mac_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "battery": {
+          "name": "battery",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signal": {
+          "name": "signal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firmware_version": {
+          "name": "firmware_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_status": {
+          "name": "claim_status",
+          "type": "device_claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'occupied'"
+        },
+        "usage_duration_minutes": {
+          "name": "usage_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "upgrade_status": {
+          "name": "upgrade_status",
+          "type": "device_upgrade_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "last_online_at": {
+          "name": "last_online_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_collar_devices_pet_id": {
+          "name": "idx_collar_devices_pet_id",
+          "columns": [
+            {
+              "expression": "pet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collar_devices_mac_address_unique": {
+          "name": "collar_devices_mac_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mac_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.desktop_devices": {
+      "name": "desktop_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mac_address": {
+          "name": "mac_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "firmware_version": {
+          "name": "firmware_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_status": {
+          "name": "claim_status",
+          "type": "device_claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'occupied'"
+        },
+        "usage_duration_minutes": {
+          "name": "usage_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "upgrade_status": {
+          "name": "upgrade_status",
+          "type": "device_upgrade_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "last_online_at": {
+          "name": "last_online_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "desktop_devices_mac_address_unique": {
+          "name": "desktop_devices_mac_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mac_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.desktop_pet_bindings": {
+      "name": "desktop_pet_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "desktop_device_id": {
+          "name": "desktop_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_type": {
+          "name": "binding_type",
+          "type": "binding_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unbound_at": {
+          "name": "unbound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_desktop_pet_bindings_device_created_at": {
+          "name": "idx_desktop_pet_bindings_device_created_at",
+          "columns": [
+            {
+              "expression": "desktop_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"desktop_pet_bindings\".\"unbound_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_desktop_pet_bindings_pet_id": {
+          "name": "idx_desktop_pet_bindings_pet_id",
+          "columns": [
+            {
+              "expression": "pet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"desktop_pet_bindings\".\"unbound_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_authorizations": {
+      "name": "device_authorizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "authorization_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'accepted'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_authorizations_from_user_id_to_user_id_pet_id_unique": {
+          "name": "device_authorizations_from_user_id_to_user_id_pet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "from_user_id",
+            "to_user_id",
+            "pet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.firmware_releases": {
+      "name": "firmware_releases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "device_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_notes": {
+          "name": "release_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_firmware_releases_device_type_version": {
+          "name": "uq_firmware_releases_device_type_version",
+          "columns": [
+            {
+              "expression": "device_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_firmware_releases_device_type_released_at": {
+          "name": "idx_firmware_releases_device_type_released_at",
+          "columns": [
+            {
+              "expression": "device_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "released_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interaction_events": {
+      "name": "interaction_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_interaction_events_pet_occurred_at": {
+          "name": "idx_interaction_events_pet_occurred_at",
+          "columns": [
+            {
+              "expression": "pet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_interaction_events_user_occurred_at": {
+          "name": "idx_interaction_events_user_occurred_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_interaction_events_device_occurred_at": {
+          "name": "idx_interaction_events_device_occurred_at",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interaction_events_user_id_users_id_fk": {
+          "name": "interaction_events_user_id_users_id_fk",
+          "tableFrom": "interaction_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interaction_events_pet_id_pets_id_fk": {
+          "name": "interaction_events_pet_id_pets_id_fk",
+          "tableFrom": "interaction_events",
+          "tableTo": "pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_codes_code_hash_unique": {
+          "name": "invite_codes_code_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "membership_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "status": {
+          "name": "status",
+          "type": "membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expire_at": {
+          "name": "expire_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_memberships_user_id": {
+          "name": "uq_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pet_avatar_actions": {
+      "name": "pet_avatar_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_avatar_id": {
+          "name": "pet_avatar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_pet_avatar_actions_avatar_sort_order": {
+          "name": "idx_pet_avatar_actions_avatar_sort_order",
+          "columns": [
+            {
+              "expression": "pet_avatar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pet_avatars": {
+      "name": "pet_avatars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_image_url": {
+          "name": "source_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additional_image_urls": {
+          "name": "additional_image_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "avatar_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reject_reason": {
+          "name": "reject_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pet_avatars_pet_created_at": {
+          "name": "idx_pet_avatars_pet_created_at",
+          "columns": [
+            {
+              "expression": "pet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pet_behaviors": {
+      "name": "pet_behaviors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collar_device_id": {
+          "name": "collar_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pets": {
+      "name": "pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_score": {
+          "name": "activity_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_enabled": {
+          "name": "message_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sound_enabled": {
+          "name": "sound_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "user_setting_theme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "language": {
+          "name": "language",
+          "type": "user_setting_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'zh-CN'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wechat_openid": {
+          "name": "wechat_openid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_quota": {
+          "name": "avatar_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_wechat_openid_unique": {
+          "name": "users_wechat_openid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wechat_openid"
+          ]
+        },
+        "users_phone_unique": {
+          "name": "users_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.authorization_status": {
+      "name": "authorization_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.avatar_status": {
+      "name": "avatar_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "done",
+        "failed",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.binding_type": {
+      "name": "binding_type",
+      "schema": "public",
+      "values": [
+        "owner",
+        "authorized"
+      ]
+    },
+    "public.device_claim_status": {
+      "name": "device_claim_status",
+      "schema": "public",
+      "values": [
+        "occupied",
+        "available",
+        "reset_required"
+      ]
+    },
+    "public.device_status": {
+      "name": "device_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline",
+        "pairing"
+      ]
+    },
+    "public.device_type": {
+      "name": "device_type",
+      "schema": "public",
+      "values": [
+        "collar",
+        "desktop"
+      ]
+    },
+    "public.device_upgrade_status": {
+      "name": "device_upgrade_status",
+      "schema": "public",
+      "values": [
+        "idle",
+        "pending",
+        "success",
+        "failed"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "unknown"
+      ]
+    },
+    "public.membership_level": {
+      "name": "membership_level",
+      "schema": "public",
+      "values": [
+        "free",
+        "basic",
+        "pro",
+        "premium"
+      ]
+    },
+    "public.membership_status": {
+      "name": "membership_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "suspended"
+      ]
+    },
+    "public.message_type": {
+      "name": "message_type",
+      "schema": "public",
+      "values": [
+        "authorization",
+        "system"
+      ]
+    },
+    "public.schedule_effective_type": {
+      "name": "schedule_effective_type",
+      "schema": "public",
+      "values": [
+        "everyday",
+        "weekday",
+        "friday"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "cat",
+        "dog"
+      ]
+    },
+    "public.user_setting_language": {
+      "name": "user_setting_language",
+      "schema": "public",
+      "values": [
+        "zh-CN",
+        "zh-TW",
+        "en-US"
+      ]
+    },
+    "public.user_setting_theme": {
+      "name": "user_setting_theme",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark",
+        "blue"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1776250800000,
       "tag": "0007_friday_schedule_rule",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1776441074827,
+      "tag": "0008_empty_sharon_carter",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,6 +16,9 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.888.0",
     "@aws-sdk/s3-request-presigner": "^3.888.0",
+    "@smithy/hash-node": "^4.2.12",
+    "@smithy/protocol-http": "^5.3.5",
+    "@smithy/signature-v4": "^5.3.14",
     "drizzle-orm": "^0.39",
     "hono": "^4",
     "postgres": "^3",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.888.0",
-    "@aws-sdk/s3-request-presigner": "^3.888.0",
     "@smithy/hash-node": "^4.2.12",
     "@smithy/protocol-http": "^5.3.5",
     "@smithy/signature-v4": "^5.3.14",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.888.0",
+    "@aws-sdk/s3-request-presigner": "^3.888.0",
     "drizzle-orm": "^0.39",
     "hono": "^4",
     "postgres": "^3",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,6 +6,7 @@
     "dev": "bun --watch src/index.ts",
     "start": "bun src/index.ts",
     "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
+    "db:seed:demo": "bun scripts/seed-admin-demo.ts",
     "db:studio": "drizzle-kit studio",
     "test": "bun test src/__tests__/"
   },

--- a/packages/server/scripts/seed-admin-demo.ts
+++ b/packages/server/scripts/seed-admin-demo.ts
@@ -407,8 +407,7 @@ async function main() {
     }
     if (bindingCleanupConditions.length > 0) {
       await tx
-        .update(desktopPetBindings)
-        .set({ unboundAt: new Date() })
+        .delete(desktopPetBindings)
         .where(or(...bindingCleanupConditions));
     }
 

--- a/packages/server/scripts/seed-admin-demo.ts
+++ b/packages/server/scripts/seed-admin-demo.ts
@@ -1,0 +1,745 @@
+#!/usr/bin/env bun
+
+import { inArray, like, or } from "drizzle-orm";
+import {
+  ALL_ACTIONS,
+  DEFAULT_FREE_BENEFITS,
+  type MembershipBenefit,
+  type MembershipLevel,
+  type MembershipStatus,
+} from "shared";
+import { db } from "../src/db";
+import {
+  memberships,
+  petAvatarActions,
+  petAvatars,
+  petBehaviors,
+  pets,
+  users,
+  desktopPetBindings,
+  deviceAuthorizations,
+  collarDevices,
+  desktopDevices,
+} from "../src/db/schema";
+
+const SEED_OPENID_PREFIX = "seed-demo:";
+const SEED_USER_COUNT = 20;
+const SEED_PET_COUNT = 30;
+const SEED_COLLAR_COUNT = 25;
+const SEED_DESKTOP_COUNT = 15;
+const SEED_AVATAR_COUNT = 40;
+const SEED_MEMBERSHIP_COUNT = 15;
+
+type DeviceStatus = "online" | "offline" | "pairing";
+type ClaimStatus = "occupied" | "available" | "reset_required";
+type UpgradeStatus = "idle" | "pending" | "success" | "failed";
+type Species = "cat" | "dog";
+type Gender = "male" | "female" | "unknown";
+type AvatarStatus =
+  | "pending"
+  | "processing"
+  | "done"
+  | "failed"
+  | "approved"
+  | "rejected";
+type BindingType = "owner" | "authorized";
+
+type MembershipSeed = {
+  userIndex: number;
+  level: MembershipLevel;
+  status: MembershipStatus;
+  expireAt: Date | null;
+  avatarQuota: number;
+  benefits: MembershipBenefit[];
+};
+
+type BindingSeed = {
+  desktopIndex: number;
+  petIndex: number;
+  bindingType: BindingType;
+  createdAt: Date;
+  unboundAt: Date | null;
+};
+
+const DEVICE_STATUSES: readonly DeviceStatus[] = ["online", "offline", "pairing"];
+const CLAIM_STATUSES: readonly ClaimStatus[] = [
+  "occupied",
+  "available",
+  "reset_required",
+];
+const UPGRADE_STATUSES: readonly UpgradeStatus[] = [
+  "idle",
+  "pending",
+  "success",
+  "failed",
+];
+const PET_SPECIES: readonly Species[] = ["cat", "dog"];
+const PET_GENDERS: readonly Gender[] = ["male", "female", "unknown"];
+const AVATAR_STATUSES: readonly AvatarStatus[] = [
+  "pending",
+  "pending",
+  "pending",
+  "pending",
+  "pending",
+  "pending",
+  "processing",
+  "processing",
+  "processing",
+  "processing",
+  "processing",
+  "processing",
+  "processing",
+  "done",
+  "done",
+  "done",
+  "done",
+  "done",
+  "done",
+  "done",
+  "failed",
+  "failed",
+  "failed",
+  "failed",
+  "failed",
+  "failed",
+  "approved",
+  "approved",
+  "approved",
+  "approved",
+  "approved",
+  "approved",
+  "rejected",
+  "rejected",
+  "rejected",
+  "rejected",
+  "rejected",
+  "rejected",
+  "rejected",
+  "rejected",
+];
+const ACTION_COUNTS_FOR_COMPLETABLE_AVATARS = [
+  ...Array.from({ length: 15 }, (_, index) => index),
+  0,
+  4,
+  7,
+  10,
+  14,
+] as const;
+
+function pad(value: number, width = 2): string {
+  return String(value).padStart(width, "0");
+}
+
+function daysAgo(days: number, hour = 9): Date {
+  const now = new Date();
+  return new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() - days,
+      hour,
+      0,
+      0,
+      0,
+    ),
+  );
+}
+
+function daysFromNow(days: number, hour = 9): Date {
+  const now = new Date();
+  return new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() + days,
+      hour,
+      0,
+      0,
+      0,
+    ),
+  );
+}
+
+function cloneBenefits(
+  benefits: readonly MembershipBenefit[],
+): MembershipBenefit[] {
+  return benefits.map((benefit) => ({ ...benefit }));
+}
+
+function buildMembershipBenefits(
+  level: MembershipLevel,
+  avatarQuota: number,
+): MembershipBenefit[] {
+  if (level === "free") {
+    return cloneBenefits(DEFAULT_FREE_BENEFITS);
+  }
+
+  return [
+    {
+      key: "avatar_generation",
+      label: "AI 形象生成",
+      value: `${avatarQuota} 次`,
+      enabled: true,
+    },
+    {
+      key: "basic_actions",
+      label: "基础动作库",
+      value: "全部开放",
+      enabled: true,
+    },
+    {
+      key: "personalized_actions",
+      label: "个性化动作库",
+      value: "全部开放",
+      enabled: true,
+    },
+    {
+      key: "priority_review",
+      label: "优先审核",
+      value:
+        level === "basic"
+          ? "加速队列"
+          : level === "pro"
+            ? "高优先级"
+            : "最高优先级",
+      enabled: true,
+    },
+  ];
+}
+
+function buildMembershipSeeds(): MembershipSeed[] {
+  const specs: Array<
+    Pick<MembershipSeed, "level" | "status" | "avatarQuota"> & {
+      expireInDays: number | null;
+    }
+  > = [
+    { level: "free", status: "active", expireInDays: null, avatarQuota: 2 },
+    { level: "basic", status: "active", expireInDays: 45, avatarQuota: 6 },
+    { level: "pro", status: "active", expireInDays: 60, avatarQuota: 12 },
+    { level: "premium", status: "active", expireInDays: 90, avatarQuota: 30 },
+    { level: "basic", status: "expired", expireInDays: -5, avatarQuota: 6 },
+    { level: "pro", status: "expired", expireInDays: -7, avatarQuota: 12 },
+    { level: "premium", status: "expired", expireInDays: -10, avatarQuota: 30 },
+    { level: "free", status: "expired", expireInDays: -3, avatarQuota: 2 },
+    { level: "basic", status: "expired", expireInDays: -1, avatarQuota: 6 },
+    { level: "premium", status: "active", expireInDays: 120, avatarQuota: 30 },
+    { level: "pro", status: "active", expireInDays: 75, avatarQuota: 12 },
+    { level: "basic", status: "active", expireInDays: 30, avatarQuota: 6 },
+    { level: "premium", status: "suspended", expireInDays: 20, avatarQuota: 30 },
+    { level: "free", status: "active", expireInDays: null, avatarQuota: 2 },
+    { level: "pro", status: "active", expireInDays: 50, avatarQuota: 12 },
+  ];
+
+  return specs.slice(0, SEED_MEMBERSHIP_COUNT).map((spec, index) => {
+    const expireAt =
+      spec.expireInDays === null ? null : daysFromNow(spec.expireInDays, 8);
+    return {
+      userIndex: index + 1,
+      level: spec.level,
+      status: spec.status,
+      expireAt,
+      avatarQuota: spec.avatarQuota,
+      benefits: buildMembershipBenefits(spec.level, spec.avatarQuota),
+    };
+  });
+}
+
+function buildDesktopBindingSeeds(): BindingSeed[] {
+  return [
+    ...Array.from({ length: 8 }, (_, index) => ({
+      desktopIndex: index + 1,
+      petIndex: index + 1,
+      bindingType: "owner" as const,
+      createdAt: daysAgo(20 - index, 10),
+      unboundAt: null,
+    })),
+    {
+      desktopIndex: 9,
+      petIndex: 9,
+      bindingType: "owner",
+      createdAt: daysAgo(12, 10),
+      unboundAt: null,
+    },
+    {
+      desktopIndex: 9,
+      petIndex: 10,
+      bindingType: "authorized",
+      createdAt: daysAgo(9, 11),
+      unboundAt: null,
+    },
+    {
+      desktopIndex: 10,
+      petIndex: 11,
+      bindingType: "owner",
+      createdAt: daysAgo(10, 10),
+      unboundAt: null,
+    },
+    {
+      desktopIndex: 10,
+      petIndex: 12,
+      bindingType: "authorized",
+      createdAt: daysAgo(7, 11),
+      unboundAt: null,
+    },
+    {
+      desktopIndex: 11,
+      petIndex: 13,
+      bindingType: "owner",
+      createdAt: daysAgo(11, 10),
+      unboundAt: null,
+    },
+    {
+      desktopIndex: 11,
+      petIndex: 14,
+      bindingType: "authorized",
+      createdAt: daysAgo(6, 11),
+      unboundAt: null,
+    },
+    {
+      desktopIndex: 12,
+      petIndex: 15,
+      bindingType: "owner",
+      createdAt: daysAgo(8, 10),
+      unboundAt: null,
+    },
+    {
+      desktopIndex: 13,
+      petIndex: 16,
+      bindingType: "owner",
+      createdAt: daysAgo(5, 10),
+      unboundAt: null,
+    },
+    {
+      desktopIndex: 9,
+      petIndex: 18,
+      bindingType: "owner",
+      createdAt: daysAgo(28, 9),
+      unboundAt: daysAgo(14, 18),
+    },
+    {
+      desktopIndex: 14,
+      petIndex: 19,
+      bindingType: "owner",
+      createdAt: daysAgo(25, 9),
+      unboundAt: daysAgo(10, 18),
+    },
+    {
+      desktopIndex: 15,
+      petIndex: 20,
+      bindingType: "authorized",
+      createdAt: daysAgo(22, 9),
+      unboundAt: daysAgo(8, 18),
+    },
+  ];
+}
+
+function getMembershipSeedForUser(
+  membershipSeeds: readonly MembershipSeed[],
+  userIndex: number,
+): MembershipSeed | undefined {
+  return membershipSeeds.find((seed) => seed.userIndex === userIndex);
+}
+
+async function main() {
+  const membershipSeeds = buildMembershipSeeds();
+  const desktopBindingSeeds = buildDesktopBindingSeeds();
+
+  const summary = await db.transaction(async (tx) => {
+    const seedUsers = await tx
+      .select({ id: users.id })
+      .from(users)
+      .where(like(users.wechatOpenid, `${SEED_OPENID_PREFIX}%`));
+    const seedUserIds = seedUsers.map((user) => user.id);
+
+    let seedPetIds: string[] = [];
+    let seedAvatarIds: string[] = [];
+    let seedDesktopIds: string[] = [];
+
+    if (seedUserIds.length > 0) {
+      const existingPets = await tx
+        .select({ id: pets.id })
+        .from(pets)
+        .where(inArray(pets.userId, seedUserIds));
+      seedPetIds = existingPets.map((pet) => pet.id);
+
+      if (seedPetIds.length > 0) {
+        const existingAvatars = await tx
+          .select({ id: petAvatars.id })
+          .from(petAvatars)
+          .where(inArray(petAvatars.petId, seedPetIds));
+        seedAvatarIds = existingAvatars.map((avatar) => avatar.id);
+      }
+
+      const existingDesktops = await tx
+        .select({ id: desktopDevices.id })
+        .from(desktopDevices)
+        .where(inArray(desktopDevices.userId, seedUserIds));
+      seedDesktopIds = existingDesktops.map((desktop) => desktop.id);
+    }
+
+    // design §6.2 cleanup order
+    if (seedAvatarIds.length > 0) {
+      await tx
+        .delete(petAvatarActions)
+        .where(inArray(petAvatarActions.petAvatarId, seedAvatarIds));
+    }
+
+    if (seedPetIds.length > 0) {
+      await tx.delete(petAvatars).where(inArray(petAvatars.petId, seedPetIds));
+    }
+
+    if (seedPetIds.length > 0) {
+      await tx
+        .delete(petBehaviors)
+        .where(inArray(petBehaviors.petId, seedPetIds));
+    }
+
+    const bindingCleanupConditions = [];
+    if (seedPetIds.length > 0) {
+      bindingCleanupConditions.push(
+        inArray(desktopPetBindings.petId, seedPetIds),
+      );
+    }
+    if (seedDesktopIds.length > 0) {
+      bindingCleanupConditions.push(
+        inArray(desktopPetBindings.desktopDeviceId, seedDesktopIds),
+      );
+    }
+    if (bindingCleanupConditions.length > 0) {
+      await tx
+        .update(desktopPetBindings)
+        .set({ unboundAt: new Date() })
+        .where(or(...bindingCleanupConditions));
+    }
+
+    if (seedUserIds.length > 0) {
+      await tx.delete(memberships).where(inArray(memberships.userId, seedUserIds));
+    }
+
+    const authorizationCleanupConditions = [];
+    if (seedUserIds.length > 0) {
+      authorizationCleanupConditions.push(
+        inArray(deviceAuthorizations.fromUserId, seedUserIds),
+        inArray(deviceAuthorizations.toUserId, seedUserIds),
+      );
+    }
+    if (seedPetIds.length > 0) {
+      authorizationCleanupConditions.push(
+        inArray(deviceAuthorizations.petId, seedPetIds),
+      );
+    }
+    if (authorizationCleanupConditions.length > 0) {
+      await tx
+        .delete(deviceAuthorizations)
+        .where(or(...authorizationCleanupConditions));
+    }
+
+    if (seedUserIds.length > 0) {
+      await tx.delete(collarDevices).where(inArray(collarDevices.userId, seedUserIds));
+      await tx
+        .delete(desktopDevices)
+        .where(inArray(desktopDevices.userId, seedUserIds));
+      await tx.delete(pets).where(inArray(pets.userId, seedUserIds));
+      await tx.delete(users).where(inArray(users.id, seedUserIds));
+    }
+
+    const insertedUsers = await tx
+      .insert(users)
+      .values(
+        Array.from({ length: SEED_USER_COUNT }, (_, index) => {
+          const userIndex = index + 1;
+          const membershipSeed = getMembershipSeedForUser(
+            membershipSeeds,
+            userIndex,
+          );
+          const createdAt = daysAgo(90 - userIndex, 9);
+
+          return {
+            wechatOpenid: `${SEED_OPENID_PREFIX}${userIndex}`,
+            phone: `1390000${pad(userIndex, 4)}`,
+            email: `seed-demo+${userIndex}@example.local`,
+            nickname: `@seed-demo-user-${userIndex}`,
+            avatarUrl: `https://seed.example.local/users/${userIndex}.png`,
+            avatarQuota: membershipSeed?.avatarQuota ?? 2,
+            createdAt,
+            updatedAt: daysAgo(20 - (userIndex % 10), 18),
+          };
+        }),
+      )
+      .returning({ id: users.id, wechatOpenid: users.wechatOpenid });
+
+    const userIdByIndex = new Map<number, string>();
+    for (const user of insertedUsers) {
+      const suffix = user.wechatOpenid?.slice(SEED_OPENID_PREFIX.length);
+      const userIndex = Number(suffix);
+      if (Number.isInteger(userIndex) && userIndex > 0) {
+        userIdByIndex.set(userIndex, user.id);
+      }
+    }
+
+    const insertedPets = await tx
+      .insert(pets)
+      .values(
+        Array.from({ length: SEED_PET_COUNT }, (_, index) => {
+          const petIndex = index + 1;
+          const userIndex = petIndex <= SEED_USER_COUNT ? petIndex : petIndex - 20;
+          const species = PET_SPECIES[index % PET_SPECIES.length];
+          const createdAt = daysAgo(55 - petIndex, 10);
+
+          return {
+            userId: userIdByIndex.get(userIndex) ?? "",
+            name: `SeedPet-${pad(petIndex)}`,
+            species,
+            breed: species === "cat" ? "british-shorthair" : "corgi",
+            gender: PET_GENDERS[index % PET_GENDERS.length],
+            birthday: `202${index % 4}-0${(index % 9) + 1}-15`,
+            weight: Number((3.2 + (index % 7) * 0.8).toFixed(1)),
+            activityScore: 40 + ((petIndex * 7) % 60),
+            createdAt,
+            updatedAt: daysAgo(15 - (petIndex % 6), 17),
+          };
+        }),
+      )
+      .returning({ id: pets.id, name: pets.name });
+
+    const petIdByIndex = new Map<number, string>();
+    for (const pet of insertedPets) {
+      const petIndex = Number(pet.name.split("-").at(-1));
+      if (Number.isInteger(petIndex) && petIndex > 0) {
+        petIdByIndex.set(petIndex, pet.id);
+      }
+    }
+
+    const insertedCollars = await tx
+      .insert(collarDevices)
+      .values(
+        Array.from({ length: SEED_COLLAR_COUNT }, (_, index) => {
+          const collarIndex = index + 1;
+          const userIndex = ((collarIndex - 1) % SEED_USER_COUNT) + 1;
+          const boundPetIndex = collarIndex <= 18 ? collarIndex : null;
+          const status = DEVICE_STATUSES[index % DEVICE_STATUSES.length];
+          const createdAt = daysAgo(50 - collarIndex, 11);
+
+          return {
+            userId: userIdByIndex.get(userIndex) ?? null,
+            petId:
+              boundPetIndex === null
+                ? null
+                : (petIdByIndex.get(boundPetIndex) ?? null),
+            name: `Seed Collar ${pad(collarIndex)}`,
+            macAddress: `AA:CC:${pad(collarIndex)}:10:${pad(
+              (collarIndex * 3) % 100,
+            )}:${pad((collarIndex * 7) % 100)}`,
+            status,
+            battery: 35 + ((collarIndex * 9) % 65),
+            signal: 45 + ((collarIndex * 5) % 55),
+            firmwareVersion: `1.${(collarIndex % 4) + 1}.${collarIndex % 10}`,
+            claimStatus: CLAIM_STATUSES[index % CLAIM_STATUSES.length],
+            usageDurationMinutes: 120 + collarIndex * 23,
+            upgradeStatus: UPGRADE_STATUSES[index % UPGRADE_STATUSES.length],
+            lastOnlineAt: status === "offline" ? null : daysAgo(collarIndex % 5, 20),
+            createdAt,
+            updatedAt: daysAgo(collarIndex % 6, 21),
+          };
+        }),
+      )
+      .returning({ id: collarDevices.id, petId: collarDevices.petId });
+
+    const collarIdByPetId = new Map<string, string>();
+    for (const collar of insertedCollars) {
+      if (collar.petId) {
+        collarIdByPetId.set(collar.petId, collar.id);
+      }
+    }
+
+    const insertedDesktops = await tx
+      .insert(desktopDevices)
+      .values(
+        Array.from({ length: SEED_DESKTOP_COUNT }, (_, index) => {
+          const desktopIndex = index + 1;
+          const status = DEVICE_STATUSES[(index + 1) % DEVICE_STATUSES.length];
+          const createdAt = daysAgo(45 - desktopIndex, 12);
+
+          return {
+            userId: userIdByIndex.get(desktopIndex) ?? null,
+            name: `Seed Desktop ${pad(desktopIndex)}`,
+            macAddress: `BB:DT:${pad(desktopIndex)}:20:${pad(
+              (desktopIndex * 4) % 100,
+            )}:${pad((desktopIndex * 9) % 100)}`,
+            status,
+            firmwareVersion: `2.${(desktopIndex % 3) + 1}.${desktopIndex % 10}`,
+            claimStatus: CLAIM_STATUSES[(index + 1) % CLAIM_STATUSES.length],
+            usageDurationMinutes: 240 + desktopIndex * 37,
+            upgradeStatus: UPGRADE_STATUSES[(index + 2) % UPGRADE_STATUSES.length],
+            lastOnlineAt: status === "offline" ? null : daysAgo(desktopIndex % 4, 19),
+            createdAt,
+            updatedAt: daysAgo(desktopIndex % 5, 22),
+          };
+        }),
+      )
+      .returning({ id: desktopDevices.id, name: desktopDevices.name });
+
+    const desktopIdByIndex = new Map<number, string>();
+    for (const desktop of insertedDesktops) {
+      const desktopIndex = Number(desktop.name.split(" ").at(-1));
+      if (Number.isInteger(desktopIndex) && desktopIndex > 0) {
+        desktopIdByIndex.set(desktopIndex, desktop.id);
+      }
+    }
+
+    await tx.insert(desktopPetBindings).values(
+      desktopBindingSeeds.map((binding) => ({
+        desktopDeviceId: desktopIdByIndex.get(binding.desktopIndex) ?? "",
+        petId: petIdByIndex.get(binding.petIndex) ?? "",
+        bindingType: binding.bindingType,
+        createdAt: binding.createdAt,
+        unboundAt: binding.unboundAt,
+      })),
+    );
+
+    const insertedAvatars = await tx
+      .insert(petAvatars)
+      .values(
+        Array.from({ length: SEED_AVATAR_COUNT }, (_, index) => {
+          const avatarIndex = index + 1;
+          const petIndex = avatarIndex <= SEED_PET_COUNT ? avatarIndex : avatarIndex - 30;
+          const status = AVATAR_STATUSES[index];
+          const createdAt = daysAgo(35 - (avatarIndex % 18), 13);
+          const reviewedAt =
+            status === "pending" || status === "processing"
+              ? null
+              : daysAgo(12 - (avatarIndex % 5), 16);
+
+          return {
+            petId: petIdByIndex.get(petIndex) ?? "",
+            sourceImageUrl: `https://seed.example.local/avatars/${avatarIndex}/source.png`,
+            additionalImageUrls:
+              avatarIndex % 4 === 0
+                ? `https://seed.example.local/avatars/${avatarIndex}/detail-1.png,https://seed.example.local/avatars/${avatarIndex}/detail-2.png`
+                : null,
+            status,
+            rejectReason:
+              status === "rejected" ? "seed-demo-auto-rejected" : null,
+            reviewedAt,
+            createdAt,
+          };
+        }),
+      )
+      .returning({
+        id: petAvatars.id,
+        sourceImageUrl: petAvatars.sourceImageUrl,
+        status: petAvatars.status,
+      });
+
+    const avatarIdByIndex = new Map<number, string>();
+    const completableAvatarIndexes: number[] = [];
+    for (const avatar of insertedAvatars) {
+      const avatarIndex = Number(avatar.sourceImageUrl.split("/").at(-2));
+      if (Number.isInteger(avatarIndex) && avatarIndex > 0) {
+        avatarIdByIndex.set(avatarIndex, avatar.id);
+        if (
+          avatar.status === "processing" ||
+          avatar.status === "done" ||
+          avatar.status === "approved"
+        ) {
+          completableAvatarIndexes.push(avatarIndex);
+        }
+      }
+    }
+
+    const actionRows: Array<typeof petAvatarActions.$inferInsert> = [];
+    completableAvatarIndexes
+      .sort((left, right) => left - right)
+      .forEach((avatarIndex, index) => {
+        const actionCount = ACTION_COUNTS_FOR_COMPLETABLE_AVATARS[index] ?? 14;
+        const avatarId = avatarIdByIndex.get(avatarIndex);
+        if (!avatarId) {
+          return;
+        }
+
+        ALL_ACTIONS.slice(0, actionCount).forEach((actionType, actionIndex) => {
+          actionRows.push({
+            petAvatarId: avatarId,
+            actionType,
+            imageUrl: `https://seed.example.local/avatars/${avatarIndex}/actions/${actionType}.png`,
+            sortOrder: actionIndex,
+          });
+        });
+      });
+
+    if (actionRows.length > 0) {
+      await tx.insert(petAvatarActions).values(actionRows);
+    }
+
+    const behaviorRows: Array<typeof petBehaviors.$inferInsert> = [];
+    for (let petIndex = 1; petIndex <= 18; petIndex += 1) {
+      const petId = petIdByIndex.get(petIndex);
+      if (!petId) {
+        continue;
+      }
+
+      const collarId = collarIdByPetId.get(petId);
+      if (!collarId) {
+        continue;
+      }
+
+      behaviorRows.push({
+        petId,
+        collarDeviceId: collarId,
+        actionType: ALL_ACTIONS[(petIndex - 1) % ALL_ACTIONS.length],
+        timestamp: daysAgo((petIndex % 7) + 1, 8),
+      });
+      behaviorRows.push({
+        petId,
+        collarDeviceId: collarId,
+        actionType: ALL_ACTIONS[(petIndex + 3) % ALL_ACTIONS.length],
+        timestamp: daysAgo(petIndex % 5, 18),
+      });
+    }
+
+    if (behaviorRows.length > 0) {
+      await tx.insert(petBehaviors).values(behaviorRows);
+    }
+
+    await tx.insert(memberships).values(
+      membershipSeeds.map((membershipSeed) => ({
+        userId: userIdByIndex.get(membershipSeed.userIndex) ?? "",
+        level: membershipSeed.level,
+        status: membershipSeed.status,
+        startAt: daysAgo(40 - membershipSeed.userIndex, 9),
+        expireAt: membershipSeed.expireAt,
+        benefits: membershipSeed.benefits,
+        createdAt: daysAgo(40 - membershipSeed.userIndex, 9),
+        updatedAt:
+          membershipSeed.status === "expired"
+            ? daysAgo(2, 21)
+            : daysAgo(1, 21),
+      })),
+    );
+
+    return {
+      users: insertedUsers.length,
+      pets: insertedPets.length,
+      collars: insertedCollars.length,
+      desktops: insertedDesktops.length,
+      bindings: desktopBindingSeeds.length,
+      avatars: insertedAvatars.length,
+      avatarActions: actionRows.length,
+      petBehaviors: behaviorRows.length,
+      memberships: membershipSeeds.length,
+    };
+  });
+
+  console.log("Seed admin demo completed");
+  console.table(summary);
+}
+
+void main()
+  .catch((error) => {
+    console.error("Seed admin demo failed");
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await db.$client.end();
+  });

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -10,6 +10,7 @@ import {
   boolean,
   pgEnum,
   index,
+  jsonb,
   unique,
   uniqueIndex,
 } from "drizzle-orm/pg-core";
@@ -74,6 +75,17 @@ export const userSettingLanguageEnum = pgEnum("user_setting_language", [
   "zh-TW",
   "en-US",
 ]);
+export const membershipLevelEnum = pgEnum("membership_level", [
+  "free",
+  "basic",
+  "pro",
+  "premium",
+]);
+export const membershipStatusEnum = pgEnum("membership_status", [
+  "active",
+  "expired",
+  "suspended",
+]);
 
 // ===== 用户 =====
 
@@ -95,6 +107,30 @@ export const users = pgTable(
       .defaultNow(),
   },
   (table) => [uniqueIndex("users_email_unique").on(table.email)],
+);
+
+export const memberships = pgTable(
+  "memberships",
+  {
+    id: text("id").primaryKey().$defaultFn(createId),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    level: membershipLevelEnum("level").notNull().default("free"),
+    status: membershipStatusEnum("status").notNull().default("active"),
+    startAt: timestamp("start_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    expireAt: timestamp("expire_at", { withTimezone: true }),
+    benefits: jsonb("benefits").notNull().default(sql`'[]'::jsonb`),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [uniqueIndex("uq_memberships_user_id").on(table.userId)],
 );
 
 // ===== 宠物 =====
@@ -119,33 +155,37 @@ export const pets = pgTable("pets", {
 
 // ===== 项圈设备 =====
 
-export const collarDevices = pgTable("collar_devices", {
-  id: text("id").primaryKey().$defaultFn(createId),
-  userId: text("user_id"),
-  petId: text("pet_id"),
-  name: text("name").notNull(),
-  macAddress: text("mac_address").notNull().unique(),
-  status: deviceStatusEnum("status").notNull().default("offline"),
-  battery: integer("battery"),
-  signal: integer("signal"),
-  firmwareVersion: text("firmware_version"),
-  claimStatus: deviceClaimStatusEnum("claim_status")
-    .notNull()
-    .default("occupied"),
-  usageDurationMinutes: integer("usage_duration_minutes")
-    .notNull()
-    .default(0),
-  upgradeStatus: deviceUpgradeStatusEnum("upgrade_status")
-    .notNull()
-    .default("idle"),
-  lastOnlineAt: timestamp("last_online_at", { withTimezone: true }),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-});
+export const collarDevices = pgTable(
+  "collar_devices",
+  {
+    id: text("id").primaryKey().$defaultFn(createId),
+    userId: text("user_id"),
+    petId: text("pet_id"),
+    name: text("name").notNull(),
+    macAddress: text("mac_address").notNull().unique(),
+    status: deviceStatusEnum("status").notNull().default("offline"),
+    battery: integer("battery"),
+    signal: integer("signal"),
+    firmwareVersion: text("firmware_version"),
+    claimStatus: deviceClaimStatusEnum("claim_status")
+      .notNull()
+      .default("occupied"),
+    usageDurationMinutes: integer("usage_duration_minutes")
+      .notNull()
+      .default(0),
+    upgradeStatus: deviceUpgradeStatusEnum("upgrade_status")
+      .notNull()
+      .default("idle"),
+    lastOnlineAt: timestamp("last_online_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [index("idx_collar_devices_pet_id").on(table.petId)],
+);
 
 // ===== 桌面端设备 =====
 
@@ -176,16 +216,27 @@ export const desktopDevices = pgTable("desktop_devices", {
 
 // ===== 桌面端-宠物绑定 =====
 
-export const desktopPetBindings = pgTable("desktop_pet_bindings", {
-  id: text("id").primaryKey().$defaultFn(createId),
-  desktopDeviceId: text("desktop_device_id").notNull(),
-  petId: text("pet_id").notNull(),
-  bindingType: bindingTypeEnum("binding_type").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  unboundAt: timestamp("unbound_at", { withTimezone: true }),
-});
+export const desktopPetBindings = pgTable(
+  "desktop_pet_bindings",
+  {
+    id: text("id").primaryKey().$defaultFn(createId),
+    desktopDeviceId: text("desktop_device_id").notNull(),
+    petId: text("pet_id").notNull(),
+    bindingType: bindingTypeEnum("binding_type").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    unboundAt: timestamp("unbound_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("idx_desktop_pet_bindings_device_created_at")
+      .on(table.desktopDeviceId, sql`${table.createdAt} desc`)
+      .where(sql`${table.unboundAt} is null`),
+    index("idx_desktop_pet_bindings_pet_id")
+      .on(table.petId)
+      .where(sql`${table.unboundAt} is null`),
+  ],
+);
 
 // ===== 设备授权 =====
 
@@ -218,26 +269,45 @@ export const inviteCodes = pgTable("invite_codes", {
 
 // ===== 宠物形象 =====
 
-export const petAvatars = pgTable("pet_avatars", {
-  id: text("id").primaryKey().$defaultFn(createId),
-  petId: text("pet_id").notNull(),
-  sourceImageUrl: text("source_image_url").notNull(),
-  additionalImageUrls: text("additional_image_urls"),
-  status: avatarStatusEnum("status").notNull().default("pending"),
-  rejectReason: text("reject_reason"),
-  reviewedAt: timestamp("reviewed_at", { withTimezone: true }),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-});
+export const petAvatars = pgTable(
+  "pet_avatars",
+  {
+    id: text("id").primaryKey().$defaultFn(createId),
+    petId: text("pet_id").notNull(),
+    sourceImageUrl: text("source_image_url").notNull(),
+    additionalImageUrls: text("additional_image_urls"),
+    status: avatarStatusEnum("status").notNull().default("pending"),
+    rejectReason: text("reject_reason"),
+    reviewedAt: timestamp("reviewed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_pet_avatars_pet_created_at").on(
+      table.petId,
+      sql`${table.createdAt} desc`,
+    ),
+  ],
+);
 
-export const petAvatarActions = pgTable("pet_avatar_actions", {
-  id: text("id").primaryKey().$defaultFn(createId),
-  petAvatarId: text("pet_avatar_id").notNull(),
-  actionType: text("action_type").notNull(),
-  imageUrl: text("image_url").notNull(),
-  sortOrder: integer("sort_order").notNull().default(0),
-});
+export const petAvatarActions = pgTable(
+  "pet_avatar_actions",
+  {
+    id: text("id").primaryKey().$defaultFn(createId),
+    petAvatarId: text("pet_avatar_id").notNull(),
+    actionType: text("action_type").notNull(),
+    imageUrl: text("image_url").notNull(),
+    sortOrder: integer("sort_order").notNull().default(0),
+  },
+  (table) => [
+    index("idx_pet_avatar_actions_avatar_sort_order").on(
+      table.petAvatarId,
+      table.sortOrder,
+      table.id,
+    ),
+  ],
+);
 
 // ===== 宠物行为 =====
 

--- a/packages/server/src/routes/admin/avatars.ts
+++ b/packages/server/src/routes/admin/avatars.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { and, asc, desc, eq } from "drizzle-orm";
+import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { ALL_ACTIONS } from "shared";
 import { db } from "../../db";
 import { messages, petAvatars, petAvatarActions, pets, users } from "../../db/schema";
@@ -496,6 +496,49 @@ avatarsRoute.post("/avatars/:id/sync", async (c) => {
         status: "done",
       },
     }),
+  });
+});
+
+avatarsRoute.get("/avatar-review/stats", async (c) => {
+  const [row] = await db.execute<{
+    pending_review: number | string;
+    approved_total: number | string;
+    synced_to_devices: number | string;
+    today_new_uploads: number | string;
+  }>(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE pa.status = 'pending')::int AS pending_review,
+      COUNT(*) FILTER (
+        WHERE pa.status IN ('approved', 'processing', 'done')
+      )::int AS approved_total,
+      COUNT(*) FILTER (
+        WHERE pa.status = 'approved'
+          AND (
+            EXISTS (
+              SELECT 1
+              FROM collar_devices cd
+              WHERE cd.pet_id = pa.pet_id
+                AND cd.status = 'online'
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM desktop_pet_bindings b
+              WHERE b.pet_id = pa.pet_id
+                AND b.unbound_at IS NULL
+            )
+          )
+      )::int AS synced_to_devices,
+      COUNT(*) FILTER (
+        WHERE pa.created_at >= date_trunc('day', now())
+      )::int AS today_new_uploads
+    FROM pet_avatars pa
+  `);
+
+  return c.json({
+    pendingReview: Number(row?.pending_review ?? 0),
+    approvedTotal: Number(row?.approved_total ?? 0),
+    syncedToDevices: Number(row?.synced_to_devices ?? 0),
+    todayNewUploads: Number(row?.today_new_uploads ?? 0),
   });
 });
 

--- a/packages/server/src/routes/admin/customization.ts
+++ b/packages/server/src/routes/admin/customization.ts
@@ -127,10 +127,10 @@ function getCustomizationTaskCtes() {
     WITH action_stats_by_avatar AS (
       SELECT
         paa.pet_avatar_id,
-        COUNT(*) FILTER (
+        COUNT(DISTINCT paa.action_type) FILTER (
           WHERE paa.action_type = ANY(${toTextArraySql(BASIC_ACTIONS)})
         )::int AS base_action_count,
-        COUNT(*) FILTER (
+        COUNT(DISTINCT paa.action_type) FILTER (
           WHERE paa.action_type = ANY(${toTextArraySql(FUN_ACTIONS)})
         )::int AS personalized_action_count
       FROM pet_avatar_actions paa

--- a/packages/server/src/routes/admin/customization.ts
+++ b/packages/server/src/routes/admin/customization.ts
@@ -14,7 +14,6 @@ const customizationRoute = new Hono();
 
 const BASE_ACTION_TOTAL = BASIC_ACTIONS.length;
 const PERSONALIZED_ACTION_TOTAL = FUN_ACTIONS.length;
-const TOTAL_ACTION_TOTAL = BASE_ACTION_TOTAL + PERSONALIZED_ACTION_TOTAL;
 const VALID_AVATAR_STATUSES = new Set<AvatarStatus>([
   "pending",
   "processing",
@@ -231,7 +230,6 @@ function toCustomizationTask(row: RawCustomizationTaskRow): CustomizationTask {
     totalActionCount: toInt(row.total_action_count),
     baseActionTotal: BASE_ACTION_TOTAL,
     personalizedActionTotal: PERSONALIZED_ACTION_TOTAL,
-    totalActionTotal: TOTAL_ACTION_TOTAL,
     categoryStatus: row.category_status,
     isNewToday: toBoolean(row.is_new_today),
     createdAt: toRequiredIsoString(row.created_at),
@@ -281,12 +279,7 @@ customizationRoute.get("/customization/tasks", async (c) => {
   const items = itemsRows.map(toCustomizationTask);
   const total = toInt(countRows[0]?.total);
 
-  return c.json({
-    ...buildPageResponse(items, total, pagination),
-    baseActionTotal: BASE_ACTION_TOTAL,
-    personalizedActionTotal: PERSONALIZED_ACTION_TOTAL,
-    totalActionTotal: TOTAL_ACTION_TOTAL,
-  });
+  return c.json(buildPageResponse(items, total, pagination));
 });
 
 export default customizationRoute;

--- a/packages/server/src/routes/admin/customization.ts
+++ b/packages/server/src/routes/admin/customization.ts
@@ -101,6 +101,10 @@ async function executeRows<T extends Record<string, unknown>>(query: SQL): Promi
   return await db.execute(query) as unknown as T[];
 }
 
+function toTextArraySql(values: readonly string[]) {
+  return sql`ARRAY[${sql.join(values.map((value) => sql`${value}`), sql`, `)}]::text[]`;
+}
+
 function parseStatuses(rawStatus: string | undefined): AvatarStatus[] | null {
   if (!rawStatus) {
     return [];
@@ -124,10 +128,10 @@ function getCustomizationTaskCtes() {
       SELECT
         paa.pet_avatar_id,
         COUNT(*) FILTER (
-          WHERE paa.action_type = ANY(${BASIC_ACTIONS}::text[])
+          WHERE paa.action_type = ANY(${toTextArraySql(BASIC_ACTIONS)})
         )::int AS base_action_count,
         COUNT(*) FILTER (
-          WHERE paa.action_type = ANY(${FUN_ACTIONS}::text[])
+          WHERE paa.action_type = ANY(${toTextArraySql(FUN_ACTIONS)})
         )::int AS personalized_action_count
       FROM pet_avatar_actions paa
       GROUP BY paa.pet_avatar_id

--- a/packages/server/src/routes/admin/customization.ts
+++ b/packages/server/src/routes/admin/customization.ts
@@ -1,0 +1,288 @@
+import { Hono } from "hono";
+import { sql, type SQL } from "drizzle-orm";
+import type {
+  AvatarStatus,
+  CustomizationTask,
+  CustomizationTaskCategoryStatus,
+  Species,
+} from "shared";
+import { BASIC_ACTIONS, FUN_ACTIONS } from "shared";
+import { db } from "../../db";
+import { buildPageResponse, parsePagination } from "../../utils/pagination";
+
+const customizationRoute = new Hono();
+
+const BASE_ACTION_TOTAL = BASIC_ACTIONS.length;
+const PERSONALIZED_ACTION_TOTAL = FUN_ACTIONS.length;
+const TOTAL_ACTION_TOTAL = BASE_ACTION_TOTAL + PERSONALIZED_ACTION_TOTAL;
+const VALID_AVATAR_STATUSES = new Set<AvatarStatus>([
+  "pending",
+  "processing",
+  "done",
+  "failed",
+  "approved",
+  "rejected",
+]);
+const VALID_CATEGORIES = new Set(["all", "base", "personalized"] as const);
+
+type CustomizationCategory = "all" | "base" | "personalized";
+
+type CustomizationListFilters = {
+  keyword: string;
+  statuses: AvatarStatus[];
+  category: CustomizationCategory;
+};
+
+type RawCustomizationTaskRow = {
+  avatar_id: string;
+  pet_id: string;
+  pet_name: string;
+  pet_species: Species;
+  user_id: string;
+  user_nickname: string;
+  status: AvatarStatus;
+  default_preview_url: string | null;
+  base_action_count: number | string | null;
+  personalized_action_count: number | string | null;
+  total_action_count: number | string | null;
+  category_status: CustomizationTaskCategoryStatus;
+  is_new_today: boolean | string | number | null;
+  created_at: Date | string;
+  reviewed_at: Date | string | null;
+};
+
+type RawCountRow = {
+  total: number | string;
+};
+
+function toInt(value: number | string | null | undefined, fallback = 0): number {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (typeof value === "string" && value.length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
+  return fallback;
+}
+
+function toBoolean(value: boolean | string | number | null | undefined): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return value !== 0;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.toLowerCase();
+    return normalized === "true" || normalized === "t" || normalized === "1";
+  }
+
+  return false;
+}
+
+function toIsoString(value: Date | string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function toRequiredIsoString(value: Date | string): string {
+  return toIsoString(value) ?? new Date(0).toISOString();
+}
+
+async function executeRows<T extends Record<string, unknown>>(query: SQL): Promise<T[]> {
+  return await db.execute(query) as unknown as T[];
+}
+
+function parseStatuses(rawStatus: string | undefined): AvatarStatus[] | null {
+  if (!rawStatus) {
+    return [];
+  }
+
+  const statuses = rawStatus
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value): value is AvatarStatus => value.length > 0);
+
+  if (statuses.some((value) => !VALID_AVATAR_STATUSES.has(value))) {
+    return null;
+  }
+
+  return Array.from(new Set(statuses));
+}
+
+function getCustomizationTaskCtes() {
+  return sql`
+    WITH action_stats_by_avatar AS (
+      SELECT
+        paa.pet_avatar_id,
+        COUNT(*) FILTER (
+          WHERE paa.action_type = ANY(${BASIC_ACTIONS}::text[])
+        )::int AS base_action_count,
+        COUNT(*) FILTER (
+          WHERE paa.action_type = ANY(${FUN_ACTIONS}::text[])
+        )::int AS personalized_action_count
+      FROM pet_avatar_actions paa
+      GROUP BY paa.pet_avatar_id
+    ),
+    first_action_preview AS (
+      SELECT DISTINCT ON (paa.pet_avatar_id)
+        paa.pet_avatar_id,
+        NULLIF(paa.image_url, '') AS first_action_image_url
+      FROM pet_avatar_actions paa
+      WHERE NULLIF(paa.image_url, '') IS NOT NULL
+      ORDER BY paa.pet_avatar_id, paa.sort_order ASC, paa.id ASC
+    ),
+    task_rows AS (
+      SELECT
+        pa.id AS avatar_id,
+        pa.pet_id,
+        p.name AS pet_name,
+        p.species AS pet_species,
+        u.id AS user_id,
+        u.nickname AS user_nickname,
+        pa.status,
+        COALESCE(
+          NULLIF(pa.source_image_url, ''),
+          fap.first_action_image_url
+        ) AS default_preview_url,
+        COALESCE(asa.base_action_count, 0)::int AS base_action_count,
+        COALESCE(asa.personalized_action_count, 0)::int AS personalized_action_count,
+        (
+          COALESCE(asa.base_action_count, 0) +
+          COALESCE(asa.personalized_action_count, 0)
+        )::int AS total_action_count,
+        CASE
+          WHEN COALESCE(asa.base_action_count, 0) = 0
+            AND COALESCE(asa.personalized_action_count, 0) = 0
+            THEN 'empty'
+          WHEN COALESCE(asa.base_action_count, 0) >= ${BASE_ACTION_TOTAL}
+            AND COALESCE(asa.personalized_action_count, 0) >= ${PERSONALIZED_ACTION_TOTAL}
+            THEN 'all_done'
+          WHEN COALESCE(asa.base_action_count, 0) >= ${BASE_ACTION_TOTAL}
+            THEN 'base_done'
+          ELSE 'partial'
+        END::text AS category_status,
+        (pa.created_at >= date_trunc('day', now())) AS is_new_today,
+        pa.created_at,
+        pa.reviewed_at
+      FROM pet_avatars pa
+      INNER JOIN pets p ON p.id = pa.pet_id
+      INNER JOIN users u ON u.id = p.user_id
+      LEFT JOIN action_stats_by_avatar asa ON asa.pet_avatar_id = pa.id
+      LEFT JOIN first_action_preview fap ON fap.pet_avatar_id = pa.id
+    )
+  `;
+}
+
+function buildCustomizationWhereClause(filters: CustomizationListFilters) {
+  const conditions: SQL[] = [];
+
+  if (filters.keyword) {
+    const keyword = `%${filters.keyword}%`;
+    conditions.push(sql`(
+      task_rows.pet_name ILIKE ${keyword}
+      OR task_rows.user_nickname ILIKE ${keyword}
+    )`);
+  }
+
+  if (filters.statuses.length > 0) {
+    conditions.push(
+      sql`task_rows.status IN (${sql.join(filters.statuses.map((status) => sql`${status}`), sql`, `)})`,
+    );
+  }
+
+  if (filters.category === "base") {
+    conditions.push(sql`task_rows.base_action_count > 0`);
+  } else if (filters.category === "personalized") {
+    conditions.push(sql`task_rows.personalized_action_count > 0`);
+  }
+
+  if (conditions.length === 0) {
+    return sql``;
+  }
+
+  return sql`WHERE ${sql.join(conditions, sql` AND `)}`;
+}
+
+function toCustomizationTask(row: RawCustomizationTaskRow): CustomizationTask {
+  return {
+    avatarId: row.avatar_id,
+    petId: row.pet_id,
+    petName: row.pet_name,
+    petSpecies: row.pet_species,
+    userId: row.user_id,
+    userNickname: row.user_nickname,
+    status: row.status,
+    defaultPreviewUrl: row.default_preview_url,
+    baseActionCount: toInt(row.base_action_count),
+    personalizedActionCount: toInt(row.personalized_action_count),
+    totalActionCount: toInt(row.total_action_count),
+    baseActionTotal: BASE_ACTION_TOTAL,
+    personalizedActionTotal: PERSONALIZED_ACTION_TOTAL,
+    totalActionTotal: TOTAL_ACTION_TOTAL,
+    categoryStatus: row.category_status,
+    isNewToday: toBoolean(row.is_new_today),
+    createdAt: toRequiredIsoString(row.created_at),
+    reviewedAt: toIsoString(row.reviewed_at),
+  };
+}
+
+customizationRoute.get("/customization/tasks", async (c) => {
+  const pagination = parsePagination(c);
+  const keyword = c.req.query("keyword")?.trim() ?? "";
+  const statuses = parseStatuses(c.req.query("status"));
+  const category = (c.req.query("category")?.trim() ?? "all") as CustomizationCategory;
+
+  if (!statuses) {
+    return c.json({ error: "Invalid status" }, 400);
+  }
+
+  if (!VALID_CATEGORIES.has(category)) {
+    return c.json({ error: "Invalid category" }, 400);
+  }
+
+  const filters: CustomizationListFilters = {
+    keyword,
+    statuses,
+    category,
+  };
+  const whereClause = buildCustomizationWhereClause(filters);
+  const baseCtes = getCustomizationTaskCtes();
+
+  const [itemsRows, countRows] = await Promise.all([
+    executeRows<RawCustomizationTaskRow>(sql`
+      ${baseCtes}
+      SELECT *
+      FROM task_rows
+      ${whereClause}
+      ORDER BY task_rows.created_at DESC, task_rows.avatar_id DESC
+      LIMIT ${pagination.pageSize} OFFSET ${pagination.offset}
+    `),
+    executeRows<RawCountRow>(sql`
+      ${baseCtes}
+      SELECT COUNT(*)::int AS total
+      FROM task_rows
+      ${whereClause}
+    `),
+  ]);
+
+  const items = itemsRows.map(toCustomizationTask);
+  const total = toInt(countRows[0]?.total);
+
+  return c.json({
+    ...buildPageResponse(items, total, pagination),
+    baseActionTotal: BASE_ACTION_TOTAL,
+    personalizedActionTotal: PERSONALIZED_ACTION_TOTAL,
+    totalActionTotal: TOTAL_ACTION_TOTAL,
+  });
+});
+
+export default customizationRoute;

--- a/packages/server/src/routes/admin/devices.ts
+++ b/packages/server/src/routes/admin/devices.ts
@@ -223,6 +223,10 @@ async function executeRows<T extends Record<string, unknown>>(query: SQL): Promi
   return await db.execute(query) as unknown as T[];
 }
 
+function toTextArraySql(values: readonly string[]) {
+  return sql`ARRAY[${sql.join(values.map((value) => sql`${value}`), sql`, `)}]::text[]`;
+}
+
 function getDeviceAggregationCtes() {
   return sql`
     WITH avatar_counts_by_pet AS (
@@ -230,7 +234,7 @@ function getDeviceAggregationCtes() {
         pa.pet_id,
         BOOL_OR(pa.status IN ('approved', 'done')) AS has_uploaded_avatar,
         COUNT(DISTINCT paa.action_type) FILTER (
-          WHERE paa.action_type = ANY(${ALL_ACTIONS}::text[])
+          WHERE paa.action_type = ANY(${toTextArraySql(ALL_ACTIONS)})
         )::int AS uploaded_actions,
         COUNT(DISTINCT pa.id) FILTER (
           WHERE pa.status IN ('approved', 'done')

--- a/packages/server/src/routes/admin/devices.ts
+++ b/packages/server/src/routes/admin/devices.ts
@@ -1,8 +1,20 @@
 import { Hono } from "hono";
-import { and, asc, desc, eq, isNotNull, isNull, type SQL } from "drizzle-orm";
+import { and, asc, desc, eq, isNotNull, isNull, sql, type SQL } from "drizzle-orm";
+import type {
+  AdminDeviceDetail,
+  AdminDeviceListItem,
+  AdminDeviceRelationItem,
+  DeviceClaimStatus,
+  DeviceStatus,
+  DeviceType,
+  DeviceUpgradeStatus,
+  Species,
+} from "shared";
+import { ALL_ACTIONS } from "shared";
 import { db } from "../../db";
 import { users, pets, collarDevices, desktopDevices, desktopPetBindings, petAvatars, petBehaviors } from "../../db/schema";
 import { createId } from "../../utils/id";
+import { buildPageResponse, parsePagination } from "../../utils/pagination";
 import { pick } from "./utils";
 
 async function validateCollarPetBinding(collarDeviceId: string, petId: string) {
@@ -17,6 +29,20 @@ async function validateCollarPetBinding(collarDeviceId: string, petId: string) {
 }
 
 const devicesRoute = new Hono();
+
+const TOTAL_ACTION_COUNT = ALL_ACTIONS.length;
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const SPECIES_LABELS: Record<Species, string> = {
+  cat: "猫",
+  dog: "狗",
+};
+const VALID_DEVICE_TYPES = new Set<DeviceType>(["collar", "desktop"]);
+const VALID_STATUS_FILTERS = new Set(["all", "online", "offline", "pairing"]);
+const VALID_BINDING_FILTERS = new Set(["all", "bound", "unbound"]);
+const VALID_IMAGE_STATUS_FILTERS = new Set(["all", "uploaded", "pending"]);
+const VALID_SPECIES_FILTERS = new Set(["all", "cat", "dog"]);
+const VALID_SORT_FIELDS = new Set(["createdAt", "lastOnlineAt"]);
+const VALID_SORT_ORDERS = new Set(["asc", "desc"]);
 
 type AdminDesktopRow = {
   desktop: typeof desktopDevices.$inferSelect;
@@ -35,6 +61,401 @@ type AdminCollarRow = {
   petSpecies: string | null;
   avatarId: string | null;
 };
+
+type RawDeviceRow = {
+  type: DeviceType;
+  id: string;
+  name: string;
+  mac_address: string;
+  status: DeviceStatus;
+  claim_status: DeviceClaimStatus;
+  upgrade_status: DeviceUpgradeStatus;
+  user_id: string | null;
+  user_nickname: string | null;
+  pet_id: string | null;
+  pet_name: string | null;
+  pet_species: Species | null;
+  pet_avatar_url: string | null;
+  battery: number | null;
+  signal: number | null;
+  last_online_at: Date | string | null;
+  created_at: Date | string;
+  has_uploaded_avatar: boolean | string | number | null;
+  avatar_uploaded: number | string | null;
+  avatar_total: number | string | null;
+  avatar_approved: number | string | null;
+  avatar_pending: number | string | null;
+  binding_count: number | string | null;
+  binding_started_at: Date | string | null;
+  owner_avatar_url?: string | null;
+};
+
+type RawCountRow = {
+  total: number | string;
+};
+
+type RawRelatedDeviceRow = {
+  type: DeviceType;
+  id: string;
+  name: string;
+  status: DeviceStatus;
+  claim_status: DeviceClaimStatus;
+  last_online_at: Date | string | null;
+  created_at: Date | string;
+};
+
+type DeviceListFilters = {
+  keyword: string;
+  type: DeviceType | "all";
+  model: string;
+  imageStatus: "all" | "uploaded" | "pending";
+  bindingStatus: "all" | "bound" | "unbound";
+  species: "all" | Species;
+  status: "all" | DeviceStatus;
+  sort: "createdAt" | "lastOnlineAt";
+  order: "asc" | "desc";
+};
+
+function toIsoString(value: Date | string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function toRequiredIsoString(value: Date | string): string {
+  return toIsoString(value) ?? new Date(0).toISOString();
+}
+
+function toInt(value: number | string | null | undefined, fallback = 0): number {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (typeof value === "string" && value.length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
+  return fallback;
+}
+
+function toNullableInt(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return toInt(value);
+}
+
+function toBoolean(value: boolean | string | number | null | undefined): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return value !== 0;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.toLowerCase();
+    return normalized === "true" || normalized === "t" || normalized === "1";
+  }
+
+  return false;
+}
+
+function calculateCompanionDays(value: Date | string | null | undefined): number {
+  if (!value) {
+    return 0;
+  }
+
+  const start = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(start.getTime())) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor((Date.now() - start.getTime()) / DAY_IN_MS));
+}
+
+function toAdminDeviceListItem(row: RawDeviceRow): AdminDeviceListItem {
+  return {
+    type: row.type,
+    id: row.id,
+    name: row.name,
+    macAddress: row.mac_address,
+    status: row.status,
+    claimStatus: row.claim_status,
+    upgradeStatus: row.upgrade_status,
+    userId: row.user_id,
+    userNickname: row.user_nickname,
+    petId: row.pet_id,
+    petName: row.pet_name,
+    petSpecies: row.pet_species,
+    petAvatarUrl: row.pet_avatar_url,
+    battery: toNullableInt(row.battery),
+    signal: toNullableInt(row.signal),
+    lastOnlineAt: toIsoString(row.last_online_at),
+    createdAt: toRequiredIsoString(row.created_at),
+    hasUploadedAvatar: toBoolean(row.has_uploaded_avatar),
+    avatarProgress: {
+      uploaded: toInt(row.avatar_uploaded),
+      total: toInt(row.avatar_total, TOTAL_ACTION_COUNT),
+    },
+    bindingCount: toInt(row.binding_count),
+  };
+}
+
+function toAdminDeviceRelationItem(row: RawRelatedDeviceRow): AdminDeviceRelationItem {
+  return {
+    type: row.type,
+    id: row.id,
+    name: row.name,
+    status: row.status,
+    claimStatus: row.claim_status,
+    lastOnlineAt: toIsoString(row.last_online_at),
+    createdAt: toRequiredIsoString(row.created_at),
+  };
+}
+
+async function executeRows<T extends Record<string, unknown>>(query: SQL): Promise<T[]> {
+  return await db.execute(query) as unknown as T[];
+}
+
+function getDeviceAggregationCtes() {
+  return sql`
+    WITH avatar_counts_by_pet AS (
+      SELECT
+        pa.pet_id,
+        BOOL_OR(pa.status IN ('approved', 'done')) AS has_uploaded_avatar,
+        COUNT(DISTINCT paa.action_type) FILTER (
+          WHERE paa.action_type = ANY(${ALL_ACTIONS}::text[])
+        )::int AS uploaded_actions,
+        COUNT(DISTINCT pa.id) FILTER (
+          WHERE pa.status IN ('approved', 'done')
+        )::int AS approved_count,
+        COUNT(DISTINCT pa.id) FILTER (
+          WHERE pa.status IN ('pending', 'processing')
+        )::int AS pending_count
+      FROM pet_avatars pa
+      LEFT JOIN pet_avatar_actions paa ON paa.pet_avatar_id = pa.id
+      GROUP BY pa.pet_id
+    ),
+    avatar_latest_by_pet AS (
+      SELECT DISTINCT ON (pa.pet_id)
+        pa.pet_id,
+        NULLIF(pa.source_image_url, '') AS pet_avatar_url
+      FROM pet_avatars pa
+      WHERE NULLIF(pa.source_image_url, '') IS NOT NULL
+      ORDER BY
+        pa.pet_id,
+        CASE WHEN pa.status IN ('approved', 'done') THEN 0 ELSE 1 END,
+        pa.created_at DESC,
+        pa.id DESC
+    ),
+    avatar_stats_by_pet AS (
+      SELECT
+        COALESCE(ac.pet_id, al.pet_id) AS pet_id,
+        COALESCE(ac.has_uploaded_avatar, false) AS has_uploaded_avatar,
+        al.pet_avatar_url,
+        COALESCE(ac.uploaded_actions, 0) AS uploaded_actions,
+        COALESCE(ac.approved_count, 0) AS approved_count,
+        COALESCE(ac.pending_count, 0) AS pending_count
+      FROM avatar_counts_by_pet ac
+      FULL OUTER JOIN avatar_latest_by_pet al ON al.pet_id = ac.pet_id
+    ),
+    desktop_binding_stats AS (
+      SELECT
+        b.desktop_device_id,
+        COUNT(*)::int AS binding_count
+      FROM desktop_pet_bindings b
+      WHERE b.unbound_at IS NULL
+      GROUP BY b.desktop_device_id
+    ),
+    desktop_latest_binding AS (
+      SELECT DISTINCT ON (b.desktop_device_id)
+        b.desktop_device_id,
+        b.pet_id,
+        b.created_at
+      FROM desktop_pet_bindings b
+      WHERE b.unbound_at IS NULL
+      ORDER BY b.desktop_device_id, b.created_at DESC, b.id DESC
+    ),
+    collar_rows AS (
+      SELECT
+        'collar'::text AS type,
+        cd.id,
+        cd.name,
+        cd.mac_address,
+        cd.status,
+        cd.claim_status,
+        cd.upgrade_status,
+        cd.user_id,
+        u.nickname AS user_nickname,
+        cd.pet_id,
+        p.name AS pet_name,
+        p.species AS pet_species,
+        aps.pet_avatar_url,
+        cd.battery,
+        cd.signal,
+        cd.last_online_at,
+        cd.created_at,
+        COALESCE(aps.has_uploaded_avatar, false) AS has_uploaded_avatar,
+        COALESCE(aps.uploaded_actions, 0) AS avatar_uploaded,
+        ${TOTAL_ACTION_COUNT}::int AS avatar_total,
+        COALESCE(aps.approved_count, 0) AS avatar_approved,
+        COALESCE(aps.pending_count, 0) AS avatar_pending,
+        CASE WHEN cd.pet_id IS NULL THEN 0 ELSE 1 END::int AS binding_count,
+        CASE WHEN cd.pet_id IS NULL THEN NULL ELSE cd.created_at END AS binding_started_at
+      FROM collar_devices cd
+      LEFT JOIN users u ON u.id = cd.user_id
+      LEFT JOIN pets p ON p.id = cd.pet_id
+      LEFT JOIN avatar_stats_by_pet aps ON aps.pet_id = cd.pet_id
+    ),
+    desktop_rows AS (
+      SELECT
+        'desktop'::text AS type,
+        dd.id,
+        dd.name,
+        dd.mac_address,
+        dd.status,
+        dd.claim_status,
+        dd.upgrade_status,
+        dd.user_id,
+        u.nickname AS user_nickname,
+        dlb.pet_id,
+        p.name AS pet_name,
+        p.species AS pet_species,
+        aps.pet_avatar_url,
+        NULL::int AS battery,
+        NULL::int AS signal,
+        dd.last_online_at,
+        dd.created_at,
+        COALESCE(aps.has_uploaded_avatar, false) AS has_uploaded_avatar,
+        COALESCE(aps.uploaded_actions, 0) AS avatar_uploaded,
+        ${TOTAL_ACTION_COUNT}::int AS avatar_total,
+        COALESCE(aps.approved_count, 0) AS avatar_approved,
+        COALESCE(aps.pending_count, 0) AS avatar_pending,
+        COALESCE(dbs.binding_count, 0) AS binding_count,
+        dlb.created_at AS binding_started_at
+      FROM desktop_devices dd
+      LEFT JOIN users u ON u.id = dd.user_id
+      LEFT JOIN desktop_binding_stats dbs ON dbs.desktop_device_id = dd.id
+      LEFT JOIN desktop_latest_binding dlb ON dlb.desktop_device_id = dd.id
+      LEFT JOIN pets p ON p.id = dlb.pet_id
+      LEFT JOIN avatar_stats_by_pet aps ON aps.pet_id = dlb.pet_id
+    ),
+    merged_devices AS (
+      SELECT * FROM collar_rows
+      UNION ALL
+      SELECT * FROM desktop_rows
+    )
+  `;
+}
+
+function buildDeviceListWhereClause(filters: DeviceListFilters) {
+  const conditions: SQL[] = [];
+
+  if (filters.keyword) {
+    const keyword = `%${filters.keyword}%`;
+    conditions.push(sql`
+      (
+        merged_devices.name ILIKE ${keyword}
+        OR merged_devices.mac_address ILIKE ${keyword}
+        OR COALESCE(merged_devices.user_nickname, '') ILIKE ${keyword}
+      )
+    `);
+  }
+
+  if (filters.type !== "all") {
+    conditions.push(sql`merged_devices.type = ${filters.type}`);
+  }
+
+  if (filters.model) {
+    conditions.push(sql`merged_devices.name ILIKE ${`${filters.model}%`}`);
+  }
+
+  if (filters.status !== "all") {
+    conditions.push(sql`merged_devices.status = ${filters.status}`);
+  }
+
+  if (filters.bindingStatus === "bound") {
+    conditions.push(sql`merged_devices.binding_count > 0`);
+  } else if (filters.bindingStatus === "unbound") {
+    conditions.push(sql`merged_devices.binding_count = 0`);
+  }
+
+  if (filters.species !== "all") {
+    conditions.push(sql`
+      (
+        (merged_devices.type = 'collar' AND merged_devices.pet_species = ${filters.species})
+        OR
+        (
+          merged_devices.type = 'desktop'
+          AND EXISTS (
+            SELECT 1
+            FROM desktop_pet_bindings b
+            INNER JOIN pets p ON p.id = b.pet_id
+            WHERE b.desktop_device_id = merged_devices.id
+              AND b.unbound_at IS NULL
+              AND p.species = ${filters.species}
+          )
+        )
+      )
+    `);
+  }
+
+  if (filters.imageStatus === "uploaded") {
+    conditions.push(sql`
+      (
+        (merged_devices.type = 'collar' AND COALESCE(merged_devices.has_uploaded_avatar, false))
+        OR
+        (
+          merged_devices.type = 'desktop'
+          AND EXISTS (
+            SELECT 1
+            FROM desktop_pet_bindings b
+            LEFT JOIN avatar_counts_by_pet ac ON ac.pet_id = b.pet_id
+            WHERE b.desktop_device_id = merged_devices.id
+              AND b.unbound_at IS NULL
+              AND COALESCE(ac.has_uploaded_avatar, false)
+          )
+        )
+      )
+    `);
+  } else if (filters.imageStatus === "pending") {
+    conditions.push(sql`
+      (
+        (merged_devices.type = 'collar' AND NOT COALESCE(merged_devices.has_uploaded_avatar, false))
+        OR
+        (
+          merged_devices.type = 'desktop'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM desktop_pet_bindings b
+            LEFT JOIN avatar_counts_by_pet ac ON ac.pet_id = b.pet_id
+            WHERE b.desktop_device_id = merged_devices.id
+              AND b.unbound_at IS NULL
+              AND COALESCE(ac.has_uploaded_avatar, false)
+          )
+        )
+      )
+    `);
+  }
+
+  if (conditions.length === 0) {
+    return sql``;
+  }
+
+  return sql`WHERE ${sql.join(conditions, sql` AND `)}`;
+}
+
+function getDeviceOrderClause(sort: DeviceListFilters["sort"], order: DeviceListFilters["order"]) {
+  const primaryColumn = sort === "lastOnlineAt" ? "last_online_at" : "created_at";
+  const direction = order.toUpperCase();
+  return sql.raw(`${primaryColumn} ${direction} NULLS LAST, type ASC, id DESC`);
+}
 
 function mapCollarRows(rows: AdminCollarRow[]) {
   const collars = new Map<
@@ -341,6 +762,219 @@ devicesRoute.post("/behaviors/auto", async (c) => {
 
   const behaviors = await db.insert(petBehaviors).values(values).returning();
   return c.json({ behaviors, count: behaviors.length }, 201);
+});
+
+devicesRoute.get("/devices", async (c) => {
+  const pagination = parsePagination(c);
+  const keyword = c.req.query("keyword")?.trim() ?? "";
+  const type = (c.req.query("type")?.trim() ?? "all") as DeviceListFilters["type"];
+  const model = c.req.query("model")?.trim() ?? "";
+  const imageStatus = (c.req.query("imageStatus")?.trim() ?? "all") as DeviceListFilters["imageStatus"];
+  const bindingStatus = (c.req.query("bindingStatus")?.trim() ?? "all") as DeviceListFilters["bindingStatus"];
+  const species = (c.req.query("species")?.trim() ?? "all") as DeviceListFilters["species"];
+  const status = (c.req.query("status")?.trim() ?? "all") as DeviceListFilters["status"];
+  const sort = (c.req.query("sort")?.trim() ?? "createdAt") as DeviceListFilters["sort"];
+  const order = (c.req.query("order")?.trim() ?? "desc") as DeviceListFilters["order"];
+
+  if (type !== "all" && !VALID_DEVICE_TYPES.has(type)) {
+    return c.json({ error: "Invalid type" }, 400);
+  }
+
+  if (!VALID_IMAGE_STATUS_FILTERS.has(imageStatus)) {
+    return c.json({ error: "Invalid imageStatus" }, 400);
+  }
+
+  if (!VALID_BINDING_FILTERS.has(bindingStatus)) {
+    return c.json({ error: "Invalid bindingStatus" }, 400);
+  }
+
+  if (!VALID_SPECIES_FILTERS.has(species)) {
+    return c.json({ error: "Invalid species" }, 400);
+  }
+
+  if (!VALID_STATUS_FILTERS.has(status)) {
+    return c.json({ error: "Invalid status" }, 400);
+  }
+
+  if (!VALID_SORT_FIELDS.has(sort)) {
+    return c.json({ error: "Invalid sort" }, 400);
+  }
+
+  if (!VALID_SORT_ORDERS.has(order)) {
+    return c.json({ error: "Invalid order" }, 400);
+  }
+
+  const filters: DeviceListFilters = {
+    keyword,
+    type,
+    model: model === "all" ? "" : model,
+    imageStatus,
+    bindingStatus,
+    species,
+    status,
+    sort,
+    order,
+  };
+  const whereClause = buildDeviceListWhereClause(filters);
+  const orderClause = getDeviceOrderClause(sort, order);
+
+  const [rows, countRows] = await Promise.all([
+    executeRows<RawDeviceRow>(sql`
+      ${getDeviceAggregationCtes()}
+      SELECT
+        merged_devices.type,
+        merged_devices.id,
+        merged_devices.name,
+        merged_devices.mac_address,
+        merged_devices.status,
+        merged_devices.claim_status,
+        merged_devices.upgrade_status,
+        merged_devices.user_id,
+        merged_devices.user_nickname,
+        merged_devices.pet_id,
+        merged_devices.pet_name,
+        merged_devices.pet_species,
+        merged_devices.pet_avatar_url,
+        merged_devices.battery,
+        merged_devices.signal,
+        merged_devices.last_online_at,
+        merged_devices.created_at,
+        merged_devices.has_uploaded_avatar,
+        merged_devices.avatar_uploaded,
+        merged_devices.avatar_total,
+        merged_devices.avatar_approved,
+        merged_devices.avatar_pending,
+        merged_devices.binding_count,
+        merged_devices.binding_started_at
+      FROM merged_devices
+      ${whereClause}
+      ORDER BY ${orderClause}
+      LIMIT ${pagination.pageSize}
+      OFFSET ${pagination.offset}
+    `),
+    executeRows<RawCountRow>(sql`
+      ${getDeviceAggregationCtes()}
+      SELECT COUNT(*)::int AS total
+      FROM merged_devices
+      ${whereClause}
+    `),
+  ]);
+
+  return c.json(
+    buildPageResponse(
+      rows.map((row) => toAdminDeviceListItem(row)),
+      toInt(countRows[0]?.total),
+      pagination,
+    ),
+  );
+});
+
+devicesRoute.get("/devices/:type/:id/detail", async (c) => {
+  const type = c.req.param("type") as DeviceType;
+  const id = c.req.param("id");
+
+  if (!VALID_DEVICE_TYPES.has(type)) {
+    return c.json({ error: "Invalid type" }, 400);
+  }
+
+  const [row] = await executeRows<RawDeviceRow>(sql`
+    ${getDeviceAggregationCtes()}
+    SELECT
+      merged_devices.type,
+      merged_devices.id,
+      merged_devices.name,
+      merged_devices.mac_address,
+      merged_devices.status,
+      merged_devices.claim_status,
+      merged_devices.upgrade_status,
+      merged_devices.user_id,
+      merged_devices.user_nickname,
+      merged_devices.pet_id,
+      merged_devices.pet_name,
+      merged_devices.pet_species,
+      merged_devices.pet_avatar_url,
+      merged_devices.battery,
+      merged_devices.signal,
+      merged_devices.last_online_at,
+      merged_devices.created_at,
+      merged_devices.has_uploaded_avatar,
+      merged_devices.avatar_uploaded,
+      merged_devices.avatar_total,
+      merged_devices.avatar_approved,
+      merged_devices.avatar_pending,
+      merged_devices.binding_count,
+      merged_devices.binding_started_at,
+      u.avatar_url AS owner_avatar_url
+    FROM merged_devices
+    LEFT JOIN users u ON u.id = merged_devices.user_id
+    WHERE merged_devices.type = ${type}
+      AND merged_devices.id = ${id}
+    LIMIT 1
+  `);
+
+  if (!row) {
+    return c.json({ error: "Device not found" }, 404);
+  }
+
+  const relatedDevices = row.user_id
+    ? await executeRows<RawRelatedDeviceRow>(sql`
+        ${getDeviceAggregationCtes()}
+        SELECT
+          merged_devices.type,
+          merged_devices.id,
+          merged_devices.name,
+          merged_devices.status,
+          merged_devices.claim_status,
+          merged_devices.last_online_at,
+          merged_devices.created_at
+        FROM merged_devices
+        WHERE merged_devices.user_id = ${row.user_id}
+          AND NOT (
+            merged_devices.type = ${row.type}
+            AND merged_devices.id = ${row.id}
+          )
+        ORDER BY
+          CASE WHEN merged_devices.type <> ${row.type} THEN 0 ELSE 1 END,
+          merged_devices.last_online_at DESC NULLS LAST,
+          merged_devices.created_at DESC,
+          merged_devices.id DESC
+      `)
+    : [];
+
+  const device = toAdminDeviceListItem(row);
+  const detail: AdminDeviceDetail = {
+    device,
+    owner:
+      row.user_id && row.user_nickname
+        ? {
+            id: row.user_id,
+            nickname: row.user_nickname,
+            avatarUrl: row.owner_avatar_url ?? null,
+          }
+        : null,
+    pet:
+      row.pet_id && row.pet_name && row.pet_species
+        ? {
+            id: row.pet_id,
+            name: row.pet_name,
+            species: row.pet_species,
+            speciesLabel: SPECIES_LABELS[row.pet_species],
+            avatarUrl: row.pet_avatar_url,
+            companionDays: calculateCompanionDays(row.binding_started_at),
+          }
+        : null,
+    relatedDevices: relatedDevices.map((item) => toAdminDeviceRelationItem(item)),
+    avatarProgress: {
+      total: toInt(row.avatar_total, TOTAL_ACTION_COUNT),
+      uploaded: toInt(row.avatar_uploaded),
+      approved: toInt(row.avatar_approved),
+      pending: toInt(row.avatar_pending),
+    },
+    lastSyncedAt: device.lastOnlineAt,
+    activatedAt: device.createdAt,
+  };
+
+  return c.json(detail);
 });
 
 export default devicesRoute;

--- a/packages/server/src/routes/admin/index.ts
+++ b/packages/server/src/routes/admin/index.ts
@@ -6,6 +6,8 @@ import statsRoute from "./stats";
 import analyticsRoute from "./analytics";
 import schedulesRoute from "./schedules";
 import avatarsRoute from "./avatars";
+import uploadsRoute from "./uploads";
+import membershipsRoute from "./memberships";
 
 const adminRoute = new Hono();
 
@@ -16,5 +18,7 @@ adminRoute.route("/", statsRoute);
 adminRoute.route("/", analyticsRoute);
 adminRoute.route("/", schedulesRoute);
 adminRoute.route("/", avatarsRoute);
+adminRoute.route("/", uploadsRoute);
+adminRoute.route("/", membershipsRoute);
 
 export default adminRoute;

--- a/packages/server/src/routes/admin/index.ts
+++ b/packages/server/src/routes/admin/index.ts
@@ -8,6 +8,7 @@ import schedulesRoute from "./schedules";
 import avatarsRoute from "./avatars";
 import uploadsRoute from "./uploads";
 import membershipsRoute from "./memberships";
+import customizationRoute from "./customization";
 
 const adminRoute = new Hono();
 
@@ -20,5 +21,6 @@ adminRoute.route("/", schedulesRoute);
 adminRoute.route("/", avatarsRoute);
 adminRoute.route("/", uploadsRoute);
 adminRoute.route("/", membershipsRoute);
+adminRoute.route("/", customizationRoute);
 
 export default adminRoute;

--- a/packages/server/src/routes/admin/memberships.ts
+++ b/packages/server/src/routes/admin/memberships.ts
@@ -49,7 +49,7 @@ function isMembershipBenefit(value: unknown): value is MembershipBenefit {
     typeof benefit.key === "string" &&
     typeof benefit.label === "string" &&
     (typeof benefit.value === "string" ||
-      typeof benefit.value === "number" ||
+      (typeof benefit.value === "number" && Number.isFinite(benefit.value)) ||
       benefit.value === null) &&
     typeof benefit.enabled === "boolean"
   );
@@ -60,11 +60,29 @@ function parseBenefits(value: unknown): MembershipBenefit[] | null {
     return null;
   }
 
-  if (!value.every(isMembershipBenefit)) {
-    return null;
+  const benefitKeys = new Set<string>();
+  const benefits: MembershipBenefit[] = [];
+
+  for (const item of value) {
+    if (!isMembershipBenefit(item)) {
+      return null;
+    }
+
+    const key = item.key.trim();
+    const label = item.label.trim();
+    if (!key || !label || benefitKeys.has(key)) {
+      return null;
+    }
+
+    benefitKeys.add(key);
+    benefits.push({
+      ...item,
+      key,
+      label,
+    });
   }
 
-  return value.map((benefit) => ({ ...benefit }));
+  return benefits;
 }
 
 function resolveStoredBenefits(value: unknown): MembershipBenefit[] {

--- a/packages/server/src/routes/admin/memberships.ts
+++ b/packages/server/src/routes/admin/memberships.ts
@@ -1,0 +1,282 @@
+import { and, eq, ne, sql } from "drizzle-orm";
+import { Hono } from "hono";
+import {
+  DEFAULT_FREE_BENEFITS,
+  MEMBERSHIP_LEVEL_LABELS,
+  type Membership,
+  type MembershipBenefit,
+  type MembershipLevel,
+  type MembershipStatus,
+} from "shared";
+import { db } from "../../db";
+import { memberships, petAvatars, pets, users } from "../../db/schema";
+
+const membershipsRoute = new Hono();
+
+const VALID_MEMBERSHIP_LEVELS = new Set<MembershipLevel>(
+  Object.keys(MEMBERSHIP_LEVEL_LABELS) as MembershipLevel[],
+);
+const VALID_MEMBERSHIP_STATUSES = new Set<MembershipStatus>([
+  "active",
+  "expired",
+  "suspended",
+]);
+
+type MembershipContext = {
+  user: typeof users.$inferSelect;
+  membership: typeof memberships.$inferSelect | null;
+};
+
+type MembershipUpdateBody = {
+  level?: unknown;
+  status?: unknown;
+  expireAt?: unknown;
+  benefits?: unknown;
+  avatarQuotaTotal?: unknown;
+};
+
+function cloneBenefits(benefits: readonly MembershipBenefit[]): MembershipBenefit[] {
+  return benefits.map((benefit) => ({ ...benefit }));
+}
+
+function isMembershipBenefit(value: unknown): value is MembershipBenefit {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const benefit = value as Record<string, unknown>;
+  return (
+    typeof benefit.key === "string" &&
+    typeof benefit.label === "string" &&
+    (typeof benefit.value === "string" ||
+      typeof benefit.value === "number" ||
+      benefit.value === null) &&
+    typeof benefit.enabled === "boolean"
+  );
+}
+
+function parseBenefits(value: unknown): MembershipBenefit[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  if (!value.every(isMembershipBenefit)) {
+    return null;
+  }
+
+  return value.map((benefit) => ({ ...benefit }));
+}
+
+function resolveStoredBenefits(value: unknown): MembershipBenefit[] {
+  const parsed = parseBenefits(value);
+  return parsed ?? cloneBenefits(DEFAULT_FREE_BENEFITS);
+}
+
+function toIsoString(value: Date | string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function parseExpireAt(value: unknown): Date | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function parseAvatarQuotaTotal(value: unknown): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    return undefined;
+  }
+
+  return value;
+}
+
+async function getMembershipContext(userId: string): Promise<MembershipContext | null> {
+  const [context] = await db
+    .select({
+      user: users,
+      membership: memberships,
+    })
+    .from(users)
+    .leftJoin(memberships, eq(memberships.userId, users.id))
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!context) {
+    return null;
+  }
+
+  return {
+    user: context.user,
+    membership: context.membership ?? null,
+  };
+}
+
+async function getAvatarQuotaUsed(userId: string): Promise<number> {
+  const [result] = await db
+    .select({
+      count: sql<number>`count(*)::int`,
+    })
+    .from(petAvatars)
+    .innerJoin(pets, eq(petAvatars.petId, pets.id))
+    .where(and(eq(pets.userId, userId), ne(petAvatars.status, "rejected")));
+
+  return Number(result?.count ?? 0);
+}
+
+async function buildMembershipResponse(userId: string): Promise<Membership | null> {
+  const context = await getMembershipContext(userId);
+
+  if (!context) {
+    return null;
+  }
+
+  const avatarQuotaUsed = await getAvatarQuotaUsed(userId);
+  const level = context.membership?.level ?? "free";
+
+  return {
+    level,
+    levelLabel: MEMBERSHIP_LEVEL_LABELS[level],
+    status: context.membership?.status ?? "active",
+    startAt: toIsoString(context.membership?.startAt ?? context.user.createdAt),
+    expireAt: toIsoString(context.membership?.expireAt ?? null),
+    benefits: context.membership
+      ? resolveStoredBenefits(context.membership.benefits)
+      : cloneBenefits(DEFAULT_FREE_BENEFITS),
+    avatarQuotaUsed,
+    avatarQuotaTotal: context.user.avatarQuota,
+  };
+}
+
+membershipsRoute.get("/users/:id/membership", async (c) => {
+  const membership = await buildMembershipResponse(c.req.param("id"));
+
+  if (!membership) {
+    return c.json({ error: "User not found" }, 404);
+  }
+
+  return c.json(membership);
+});
+
+membershipsRoute.put("/users/:id/membership", async (c) => {
+  const userId = c.req.param("id");
+  const body = await c.req.json<MembershipUpdateBody>();
+
+  if (!VALID_MEMBERSHIP_LEVELS.has(body.level as MembershipLevel)) {
+    return c.json({ error: "Invalid membership level" }, 400);
+  }
+
+  if (
+    body.status !== undefined &&
+    !VALID_MEMBERSHIP_STATUSES.has(body.status as MembershipStatus)
+  ) {
+    return c.json({ error: "Invalid membership status" }, 400);
+  }
+
+  const expireAt = parseExpireAt(body.expireAt);
+  if (body.expireAt !== undefined && expireAt === undefined) {
+    return c.json({ error: "Invalid expireAt" }, 400);
+  }
+
+  const nextBenefits =
+    body.benefits === undefined ? undefined : parseBenefits(body.benefits);
+  if (body.benefits !== undefined && !nextBenefits) {
+    return c.json({ error: "Invalid benefits" }, 400);
+  }
+
+  const avatarQuotaTotal = parseAvatarQuotaTotal(body.avatarQuotaTotal);
+  if (body.avatarQuotaTotal !== undefined && avatarQuotaTotal === undefined) {
+    return c.json({ error: "Invalid avatarQuotaTotal" }, 400);
+  }
+
+  const level = body.level as MembershipLevel;
+
+  const updated = await db.transaction(async (tx) => {
+    const [context] = await tx
+      .select({
+        user: users,
+        membership: memberships,
+      })
+      .from(users)
+      .leftJoin(memberships, eq(memberships.userId, users.id))
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    if (!context) {
+      return null;
+    }
+
+    const currentBenefits = context.membership
+      ? resolveStoredBenefits(context.membership.benefits)
+      : cloneBenefits(DEFAULT_FREE_BENEFITS);
+
+    const nextAvatarQuotaTotal = avatarQuotaTotal ?? context.user.avatarQuota;
+
+    await tx
+      .update(users)
+      .set({
+        avatarQuota: nextAvatarQuotaTotal,
+        updatedAt: new Date(),
+      })
+      .where(eq(users.id, userId));
+
+    await tx
+      .insert(memberships)
+      .values({
+        userId,
+        level,
+        status: (body.status as MembershipStatus | undefined) ?? context.membership?.status ?? "active",
+        expireAt:
+          expireAt === undefined ? (context.membership?.expireAt ?? null) : expireAt,
+        benefits: nextBenefits ?? currentBenefits,
+      })
+      .onConflictDoUpdate({
+        target: memberships.userId,
+        set: {
+          level,
+          status:
+            (body.status as MembershipStatus | undefined) ??
+            context.membership?.status ??
+            "active",
+          expireAt:
+            expireAt === undefined ? (context.membership?.expireAt ?? null) : expireAt,
+          benefits: nextBenefits ?? currentBenefits,
+          updatedAt: new Date(),
+        },
+      });
+
+    return true;
+  });
+
+  if (!updated) {
+    return c.json({ error: "User not found" }, 404);
+  }
+
+  const membership = await buildMembershipResponse(userId);
+
+  if (!membership) {
+    return c.json({ error: "User not found" }, 404);
+  }
+
+  return c.json(membership);
+});
+
+export default membershipsRoute;

--- a/packages/server/src/routes/admin/uploads.ts
+++ b/packages/server/src/routes/admin/uploads.ts
@@ -1,0 +1,34 @@
+import { Hono } from "hono";
+import { ALLOWED_IMAGE_CONTENT_TYPES, createPresignedPutUrl } from "../../utils/storage";
+
+const uploadsRoute = new Hono();
+
+type AllowedContentType = keyof typeof ALLOWED_IMAGE_CONTENT_TYPES;
+
+function isAllowedContentType(value: unknown): value is AllowedContentType {
+  return (
+    typeof value === "string" &&
+    Object.prototype.hasOwnProperty.call(ALLOWED_IMAGE_CONTENT_TYPES, value)
+  );
+}
+
+uploadsRoute.post("/uploads/presign", async (c) => {
+  if (process.env.ENABLE_DEV_LOGIN === "true") {
+    return c.json({ error: "Presigned uploads are not available in dev mode" }, 501);
+  }
+
+  const body = await c.req.json<{ contentType?: unknown }>();
+
+  if (!isAllowedContentType(body.contentType)) {
+    return c.json({ error: "Unsupported contentType" }, 400);
+  }
+
+  const presign = await createPresignedPutUrl({
+    contentType: body.contentType,
+    scope: "admin",
+  });
+
+  return c.json(presign);
+});
+
+export default uploadsRoute;

--- a/packages/server/src/utils/pagination.ts
+++ b/packages/server/src/utils/pagination.ts
@@ -1,0 +1,42 @@
+import type { Context } from "hono";
+
+export interface PageParams {
+  page: number;
+  pageSize: number;
+  offset: number;
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  const normalized = Math.trunc(parsed);
+  return normalized > 0 ? normalized : fallback;
+}
+
+export function parsePagination(c: Context): PageParams {
+  const page = parsePositiveInt(c.req.query("page"), 1);
+  const requestedPageSize = parsePositiveInt(c.req.query("pageSize"), 20);
+  const pageSize = Math.min(100, requestedPageSize);
+
+  return {
+    page,
+    pageSize,
+    offset: (page - 1) * pageSize,
+  };
+}
+
+export function buildPageResponse<T>(
+  items: T[],
+  total: number,
+  params: Pick<PageParams, "page" | "pageSize">,
+) {
+  return {
+    items,
+    total,
+    page: params.page,
+    pageSize: params.pageSize,
+  };
+}

--- a/packages/server/src/utils/storage.ts
+++ b/packages/server/src/utils/storage.ts
@@ -4,8 +4,11 @@ import {
   HeadBucketCommand,
   CreateBucketCommand,
 } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import type { PresignResponse } from "shared";
+import { createId } from "./id";
 
 const s3 = new S3Client({
   endpoint: process.env.S3_ENDPOINT ?? "http://localhost:9000",
@@ -20,6 +23,11 @@ const s3 = new S3Client({
 export const BUCKET = process.env.S3_BUCKET ?? "pet-uploads";
 const LOCAL_STORAGE_ROOT = path.resolve(process.cwd(), "storage");
 let ensureBucketPromise: Promise<void> | null = null;
+export const ALLOWED_IMAGE_CONTENT_TYPES = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+} as const;
 
 export async function ensureBucket(): Promise<void> {
   if (!ensureBucketPromise) {
@@ -74,4 +82,42 @@ export async function uploadFile(
   );
   const endpoint = process.env.S3_PUBLIC_URL ?? "http://localhost:9000";
   return `${endpoint}/${BUCKET}/${key}`;
+}
+
+export async function createPresignedPutUrl(opts: {
+  contentType: keyof typeof ALLOWED_IMAGE_CONTENT_TYPES;
+  scope?: string;
+}): Promise<PresignResponse> {
+  await ensureBucket();
+
+  const now = new Date();
+  const ext = ALLOWED_IMAGE_CONTENT_TYPES[opts.contentType];
+  const key = `uploads/${opts.scope ?? "admin"}/${now.getUTCFullYear()}/${String(
+    now.getUTCMonth() + 1,
+  ).padStart(2, "0")}/${createId()}.${ext}`;
+  const expiresIn = 900;
+  const signUrl = getSignedUrl as unknown as (
+    client: unknown,
+    command: unknown,
+    options: { expiresIn: number },
+  ) => Promise<string>;
+
+  const uploadUrl = await signUrl(
+    s3,
+    new PutObjectCommand({
+      Bucket: BUCKET,
+      Key: key,
+      ContentType: opts.contentType,
+      ACL: "public-read",
+    }),
+    { expiresIn },
+  );
+  const endpoint = process.env.S3_PUBLIC_URL ?? "http://localhost:9000";
+
+  return {
+    uploadUrl,
+    publicUrl: `${endpoint}/${BUCKET}/${key}`,
+    key,
+    expiresAt: new Date(Date.now() + expiresIn * 1000).toISOString(),
+  };
 }

--- a/packages/server/src/utils/storage.ts
+++ b/packages/server/src/utils/storage.ts
@@ -4,10 +4,12 @@ import {
   HeadBucketCommand,
   CreateBucketCommand,
 } from "@aws-sdk/client-s3";
-import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { PresignResponse } from "shared";
+import { Hash } from "@smithy/hash-node";
+import { HttpRequest } from "@smithy/protocol-http";
+import { SignatureV4 } from "@smithy/signature-v4";
 import { createId } from "./id";
 
 const s3 = new S3Client({
@@ -90,34 +92,61 @@ export async function createPresignedPutUrl(opts: {
 }): Promise<PresignResponse> {
   await ensureBucket();
 
-  const now = new Date();
+  const signingDate = new Date();
   const ext = ALLOWED_IMAGE_CONTENT_TYPES[opts.contentType];
-  const key = `uploads/${opts.scope ?? "admin"}/${now.getUTCFullYear()}/${String(
-    now.getUTCMonth() + 1,
+  const key = `uploads/${opts.scope ?? "admin"}/${signingDate.getUTCFullYear()}/${String(
+    signingDate.getUTCMonth() + 1,
   ).padStart(2, "0")}/${createId()}.${ext}`;
   const expiresIn = 900;
-  const signUrl = getSignedUrl as unknown as (
-    client: unknown,
-    command: unknown,
-    options: { expiresIn: number },
-  ) => Promise<string>;
-
-  const uploadUrl = await signUrl(
-    s3,
-    new PutObjectCommand({
-      Bucket: BUCKET,
-      Key: key,
-      ContentType: opts.contentType,
-      ACL: "public-read",
-    }),
-    { expiresIn },
+  const endpoint = new URL(process.env.S3_ENDPOINT ?? "http://localhost:9000");
+  const basePath = endpoint.pathname === "/" ? "" : endpoint.pathname.replace(/\/$/, "");
+  const signer = new SignatureV4({
+    service: "s3",
+    region: "us-east-1",
+    credentials: {
+      accessKeyId: process.env.S3_ACCESS_KEY ?? "minioadmin",
+      secretAccessKey: process.env.S3_SECRET_KEY ?? "minioadmin",
+    },
+    sha256: Hash.bind(null, "sha256"),
+    uriEscapePath: false,
+  });
+  const request = new HttpRequest({
+    protocol: endpoint.protocol,
+    hostname: endpoint.hostname,
+    port: endpoint.port ? Number(endpoint.port) : undefined,
+    method: "PUT",
+    path: `${basePath}/${BUCKET}/${key}`,
+    headers: {
+      host: endpoint.host,
+      "content-type": opts.contentType,
+      "x-amz-acl": "public-read",
+      "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
+    },
+  });
+  const presigned = await signer.presign(request, {
+    expiresIn,
+    signingDate,
+    unhoistableHeaders: new Set(["content-type"]),
+  });
+  const uploadUrl = new URL(
+    `${presigned.protocol}//${presigned.hostname}${presigned.port ? `:${presigned.port}` : ""}${presigned.path}`,
   );
-  const endpoint = process.env.S3_PUBLIC_URL ?? "http://localhost:9000";
+  for (const [name, value] of Object.entries(presigned.query ?? {})) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        uploadUrl.searchParams.append(name, item);
+      }
+      continue;
+    }
+
+    uploadUrl.searchParams.set(name, String(value));
+  }
+  const publicEndpoint = process.env.S3_PUBLIC_URL ?? "http://localhost:9000";
 
   return {
-    uploadUrl,
-    publicUrl: `${endpoint}/${BUCKET}/${key}`,
+    uploadUrl: uploadUrl.toString(),
+    publicUrl: `${publicEndpoint}/${BUCKET}/${key}`,
     key,
-    expiresAt: new Date(Date.now() + expiresIn * 1000).toISOString(),
+    expiresAt: new Date(signingDate.getTime() + expiresIn * 1000).toISOString(),
   };
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,5 +2,11 @@
   "name": "shared",
   "private": true,
   "main": "./src/index.ts",
-  "types": "./src/index.ts"
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit -p tsconfig.json"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -47,3 +47,37 @@ export const ACTION_LABELS: Record<string, string> = {
 };
 
 export const SCHEDULE_SPECIES = ["cat", "dog", "other"] as const;
+
+export const MEMBERSHIP_LEVEL_LABELS = {
+  free: "免费版",
+  basic: "基础版",
+  pro: "专业版",
+  premium: "旗舰版",
+} as const;
+
+export const DEFAULT_FREE_BENEFITS = [
+  {
+    key: "avatar_generation",
+    label: "AI 形象生成",
+    value: "2 次",
+    enabled: true,
+  },
+  {
+    key: "basic_actions",
+    label: "基础动作库",
+    value: `${BASIC_ACTIONS.length} 项`,
+    enabled: true,
+  },
+  {
+    key: "personalized_actions",
+    label: "个性化动作库",
+    value: `${FUN_ACTIONS.length} 项`,
+    enabled: false,
+  },
+  {
+    key: "priority_review",
+    label: "优先审核",
+    value: "标准队列",
+    enabled: false,
+  },
+] as const;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -280,6 +280,7 @@ export interface CustomizationTask {
   totalActionCount: number;
   baseActionTotal: number;
   personalizedActionTotal: number;
+  totalActionTotal: number;
   categoryStatus: CustomizationTaskCategoryStatus;
   isNewToday: boolean;
   createdAt: string;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,4 +1,9 @@
-import { SCHEDULE_SPECIES, type ActionType } from "./constants";
+import {
+  DEFAULT_FREE_BENEFITS,
+  MEMBERSHIP_LEVEL_LABELS,
+  SCHEDULE_SPECIES,
+  type ActionType,
+} from "./constants";
 
 // ===== 枚举 =====
 
@@ -22,6 +27,8 @@ export type DeviceUpgradeStatus = "idle" | "pending" | "success" | "failed";
 export type UserSettingTheme = "system" | "light" | "dark" | "blue";
 export type UserSettingLanguage = "zh-CN" | "zh-TW" | "en-US";
 export type ContentSlug = "help" | "about" | "privacy" | "user-agreement";
+export type MembershipLevel = keyof typeof MEMBERSHIP_LEVEL_LABELS;
+export type MembershipStatus = "active" | "expired" | "suspended";
 
 // ===== 用户 =====
 
@@ -35,6 +42,24 @@ export interface User {
   avatarQuota: number;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface MembershipBenefit {
+  key: string;
+  label: string;
+  value: string | number | null;
+  enabled: boolean;
+}
+
+export interface Membership {
+  level: MembershipLevel;
+  levelLabel: (typeof MEMBERSHIP_LEVEL_LABELS)[MembershipLevel];
+  status: MembershipStatus;
+  startAt: string | null;
+  expireAt: string | null;
+  benefits: MembershipBenefit[];
+  avatarQuotaUsed: number;
+  avatarQuotaTotal: number;
 }
 
 // ===== 宠物 =====
@@ -136,6 +161,74 @@ export interface DesktopPetBinding {
   unboundAt: string | null;
 }
 
+export interface AdminDeviceAvatarProgress {
+  uploaded: number;
+  total: number;
+}
+
+export interface AdminDeviceListItem {
+  type: DeviceType;
+  id: string;
+  name: string;
+  macAddress: string;
+  status: DeviceStatus;
+  claimStatus: DeviceClaimStatus;
+  upgradeStatus: DeviceUpgradeStatus;
+  userId: string | null;
+  userNickname: string | null;
+  petId: string | null;
+  petName: string | null;
+  petSpecies: Species | null;
+  petAvatarUrl: string | null;
+  battery: number | null;
+  signal: number | null;
+  lastOnlineAt: string | null;
+  createdAt: string;
+  hasUploadedAvatar: boolean;
+  avatarProgress: AdminDeviceAvatarProgress;
+  bindingCount: number;
+}
+
+export interface AdminDeviceDetailOwner {
+  id: string;
+  nickname: string;
+  avatarUrl: string | null;
+}
+
+export interface AdminDeviceDetailPet {
+  id: string;
+  name: string;
+  species: Species;
+  speciesLabel: string;
+  avatarUrl: string | null;
+  companionDays: number;
+}
+
+export interface AdminDeviceRelationItem {
+  type: DeviceType;
+  id: string;
+  name: string;
+  status: DeviceStatus;
+  claimStatus: DeviceClaimStatus;
+  lastOnlineAt: string | null;
+  createdAt: string;
+}
+
+export interface AdminDeviceDetailAvatarProgress extends AdminDeviceAvatarProgress {
+  approved: number;
+  pending: number;
+}
+
+export interface AdminDeviceDetail {
+  device: AdminDeviceListItem;
+  owner: AdminDeviceDetailOwner | null;
+  pet: AdminDeviceDetailPet | null;
+  relatedDevices: AdminDeviceRelationItem[];
+  avatarProgress: AdminDeviceDetailAvatarProgress;
+  lastSyncedAt: string | null;
+  activatedAt: string;
+}
+
 // ===== 设备授权 =====
 
 export interface DeviceAuthorization {
@@ -165,6 +258,46 @@ export interface PetAvatarAction {
   actionType: string;
   imageUrl: string;
   sortOrder: number;
+}
+
+export type CustomizationTaskCategoryStatus =
+  | "empty"
+  | "partial"
+  | "base_done"
+  | "all_done";
+
+export interface CustomizationTask {
+  avatarId: string;
+  petId: string;
+  petName: string;
+  petSpecies: Species;
+  userId: string;
+  userNickname: string;
+  status: AvatarStatus;
+  defaultPreviewUrl: string | null;
+  baseActionCount: number;
+  personalizedActionCount: number;
+  totalActionCount: number;
+  baseActionTotal: number;
+  personalizedActionTotal: number;
+  categoryStatus: CustomizationTaskCategoryStatus;
+  isNewToday: boolean;
+  createdAt: string;
+  reviewedAt: string | null;
+}
+
+export interface AvatarReviewStats {
+  pendingReview: number;
+  approvedTotal: number;
+  syncedToDevices: number;
+  todayNewUploads: number;
+}
+
+export interface PresignResponse {
+  uploadUrl: string;
+  publicUrl: string;
+  key: string;
+  expiresAt: string;
 }
 
 export interface BehaviorSchedule {
@@ -237,6 +370,8 @@ export interface InvitePayload {
   petName: string;
   fromNickname: string;
 }
+
+export type DefaultFreeBenefit = (typeof DEFAULT_FREE_BENEFITS)[number];
 
 // ===== 用户设置 =====
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -280,7 +280,6 @@ export interface CustomizationTask {
   totalActionCount: number;
   baseActionTotal: number;
   personalizedActionTotal: number;
-  totalActionTotal: number;
   categoryStatus: CustomizationTaskCategoryStatus;
   isNewToday: boolean;
   createdAt: string;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,15 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.888.0
         version: 3.1031.0
+      '@smithy/hash-node':
+        specifier: ^4.2.12
+        version: 4.2.12
+      '@smithy/protocol-http':
+        specifier: ^5.3.5
+        version: 5.3.14
+      '@smithy/signature-v4':
+        specifier: ^5.3.14
+        version: 5.3.14
       drizzle-orm:
         specifier: ^0.39
         version: 0.39.3(bun-types@1.3.12)(postgres@3.4.8)
@@ -2639,10 +2648,6 @@ packages:
     resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/protocol-http@5.3.12':
-    resolution: {integrity: sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/protocol-http@5.3.14':
     resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
     engines: {node: '>=18.0.0'}
@@ -2673,10 +2678,6 @@ packages:
 
   '@smithy/shared-ini-file-loader@4.4.9':
     resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/signature-v4@5.3.12':
-    resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.3.14':
@@ -8829,7 +8830,7 @@ snapshots:
       '@smithy/middleware-stack': 4.2.12
       '@smithy/node-config-provider': 4.3.12
       '@smithy/node-http-handler': 4.4.16
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.5
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
@@ -8855,8 +8856,8 @@ snapshots:
       '@smithy/core': 3.23.11
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
       '@smithy/smithy-client': 4.12.5
       '@smithy/types': 4.13.1
       '@smithy/util-base64': 4.3.2
@@ -8900,7 +8901,7 @@ snapshots:
       '@smithy/fetch-http-handler': 5.3.15
       '@smithy/node-http-handler': 4.4.16
       '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.5
       '@smithy/types': 4.13.1
       '@smithy/util-stream': 4.5.19
@@ -8931,7 +8932,7 @@ snapshots:
       '@aws-sdk/nested-clients': 3.996.10
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
       tslib: 2.8.1
@@ -8994,7 +8995,7 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-arn-parser': 3.972.3
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.13.1
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
@@ -9002,7 +9003,7 @@ snapshots:
   '@aws-sdk/middleware-expect-continue@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
@@ -9016,7 +9017,7 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@smithy/is-array-buffer': 4.2.2
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.13.1
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-stream': 4.5.19
@@ -9026,7 +9027,7 @@ snapshots:
   '@aws-sdk/middleware-host-header@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
@@ -9046,7 +9047,7 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.973.6
       '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
@@ -9057,8 +9058,8 @@ snapshots:
       '@aws-sdk/util-arn-parser': 3.972.3
       '@smithy/core': 3.23.11
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
       '@smithy/smithy-client': 4.12.5
       '@smithy/types': 4.13.1
       '@smithy/util-config-provider': 4.2.2
@@ -9096,7 +9097,7 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@smithy/core': 3.23.11
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.13.1
       '@smithy/util-retry': 4.2.12
       tslib: 2.8.1
@@ -9127,7 +9128,7 @@ snapshots:
       '@smithy/middleware-stack': 4.2.12
       '@smithy/node-config-provider': 4.3.12
       '@smithy/node-http-handler': 4.4.16
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.5
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
@@ -9176,8 +9177,8 @@ snapshots:
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.20
       '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
@@ -11558,7 +11559,7 @@ snapshots:
 
   '@smithy/core@3.23.11':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
       '@smithy/util-base64': 4.3.2
@@ -11622,7 +11623,7 @@ snapshots:
 
   '@smithy/fetch-http-handler@5.3.15':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/querystring-builder': 4.2.12
       '@smithy/types': 4.13.1
       '@smithy/util-base64': 4.3.2
@@ -11645,7 +11646,7 @@ snapshots:
 
   '@smithy/hash-node@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.1
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
@@ -11677,7 +11678,7 @@ snapshots:
 
   '@smithy/middleware-content-length@4.2.12':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
@@ -11706,7 +11707,7 @@ snapshots:
   '@smithy/middleware-retry@4.4.42':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/service-error-classification': 4.2.12
       '@smithy/smithy-client': 4.12.5
       '@smithy/types': 4.13.1
@@ -11718,7 +11719,7 @@ snapshots:
   '@smithy/middleware-serde@4.2.14':
     dependencies:
       '@smithy/core': 3.23.11
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
@@ -11756,7 +11757,7 @@ snapshots:
   '@smithy/node-http-handler@4.4.16':
     dependencies:
       '@smithy/abort-controller': 4.2.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/querystring-builder': 4.2.12
       '@smithy/types': 4.13.1
       tslib: 2.8.1
@@ -11776,11 +11777,6 @@ snapshots:
   '@smithy/property-provider@4.2.14':
     dependencies:
       '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/protocol-http@5.3.12':
-    dependencies:
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/protocol-http@5.3.14':
@@ -11824,17 +11820,6 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/signature-v4@5.3.12':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.2
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-uri-escape': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
   '@smithy/signature-v4@5.3.14':
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
@@ -11861,7 +11846,7 @@ snapshots:
       '@smithy/core': 3.23.11
       '@smithy/middleware-endpoint': 4.4.25
       '@smithy/middleware-stack': 4.2.12
-      '@smithy/protocol-http': 5.3.12
+      '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.13.1
       '@smithy/util-stream': 4.5.19
       tslib: 2.8.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.888.0
         version: 3.1009.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.888.0
+        version: 3.1031.0
       drizzle-orm:
         specifier: ^0.39
         version: 0.39.3(bun-types@1.3.12)(postgres@3.4.8)
@@ -244,6 +247,10 @@ packages:
     resolution: {integrity: sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.0':
+    resolution: {integrity: sha512-8j+dMtyDqNXFmi09CBdz8TY6Ltf2jhfHuP6ZvG4zVjndRc6JF0aeBUbRwQLndbptFCsdctRQgdNWecy4TIfXAw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/crc64-nvme@3.972.5':
     resolution: {integrity: sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==}
     engines: {node: '>=20.0.0'}
@@ -312,6 +319,10 @@ packages:
     resolution: {integrity: sha512-yhva/xL5H4tWQgsBjwV+RRD0ByCzg0TcByDCLp3GXdn/wlyRNfy8zsswDtCvr1WSKQkSQYlyEzPuWkJG0f5HvQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-s3@3.972.29':
+    resolution: {integrity: sha512-ayk68penP1WDZmyDZVeUQzq+HI3iDq5xezohUxIQoKFKE0KdCnDcxLCNnLanhBfgQDaKiGHVXhxZMDWJAEEBsQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-ssec@3.972.8':
     resolution: {integrity: sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==}
     engines: {node: '>=20.0.0'}
@@ -328,6 +339,14 @@ packages:
     resolution: {integrity: sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/s3-request-presigner@3.1031.0':
+    resolution: {integrity: sha512-mM7Qx3NEQvX2dKGFxRaE/SSSiiBqRszSGpLPsNHJQNCBhlrm6/H7Vf0s/wTHZcWcM9GCJKZj46DLuOSKT1GKCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.17':
+    resolution: {integrity: sha512-qDwhXw+SIM5vMAMgflA8LPRa7xP+/wgXYr++llzCOwp7kkM2v7GGGWzoRW8e1CACaO4ljZd/NSQbsRLKm1sMWw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.8':
     resolution: {integrity: sha512-n1qYFD+tbqZuyskVaxUE+t10AUz9g3qzDw3Tp6QZDKmqsjfDmZBd4GIk2EKJJNtcCBtE5YiUjDYA+3djFAFBBg==}
     engines: {node: '>=20.0.0'}
@@ -340,12 +359,20 @@ packages:
     resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/util-arn-parser@3.972.3':
     resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-endpoints@3.996.5':
     resolution: {integrity: sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-format-url@3.972.10':
+    resolution: {integrity: sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.5':
@@ -366,6 +393,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.11':
     resolution: {integrity: sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.18':
+    resolution: {integrity: sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -2488,6 +2519,10 @@ packages:
     resolution: {integrity: sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.23.15':
+    resolution: {integrity: sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.12':
     resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
     engines: {node: '>=18.0.0'}
@@ -2514,6 +2549,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.3.15':
     resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.17':
+    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.2.13':
@@ -2552,6 +2591,10 @@ packages:
     resolution: {integrity: sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-endpoint@4.4.30':
+    resolution: {integrity: sha512-qS2XqhKeXmdZ4nEQ4cOxIczSP/Y91wPAHYuRwmWDCh975B7/57uxsm5d6sisnUThn2u2FwzMdJNM7AbO1YPsPg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/middleware-retry@4.4.42':
     resolution: {integrity: sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==}
     engines: {node: '>=18.0.0'}
@@ -2560,32 +2603,64 @@ packages:
     resolution: {integrity: sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-serde@4.2.18':
+    resolution: {integrity: sha512-M6CSgnp3v4tYz9ynj2JHbA60woBZcGqEwNjTKjBsNHPV26R1ZX52+0wW8WsZU18q45jD0tw2wL22S17Ze9LpEw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/middleware-stack@4.2.12':
     resolution: {integrity: sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.14':
+    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-config-provider@4.3.12':
     resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-config-provider@4.3.14':
+    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-http-handler@4.4.16':
     resolution: {integrity: sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.5.3':
+    resolution: {integrity: sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/property-provider@4.2.12':
     resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/property-provider@4.2.14':
+    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/protocol-http@5.3.12':
     resolution: {integrity: sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.14':
+    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/querystring-builder@4.2.12':
     resolution: {integrity: sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/querystring-builder@4.2.14':
+    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/querystring-parser@4.2.12':
     resolution: {integrity: sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.14':
+    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/service-error-classification@4.2.12':
@@ -2596,8 +2671,20 @@ packages:
     resolution: {integrity: sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/shared-ini-file-loader@4.4.9':
+    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/signature-v4@5.3.12':
     resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.14':
+    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.11':
+    resolution: {integrity: sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.12.5':
@@ -2608,8 +2695,16 @@ packages:
     resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/url-parser@4.2.12':
     resolution: {integrity: sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.14':
+    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-base64@4.3.2':
@@ -2656,12 +2751,20 @@ packages:
     resolution: {integrity: sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-middleware@4.2.14':
+    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-retry@4.2.12':
     resolution: {integrity: sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-stream@4.5.19':
     resolution: {integrity: sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.23':
+    resolution: {integrity: sha512-N6on1+ngJ3RznZOnDWNveIwnTSlqxNnXuNAh7ez889ZZaRdXoNRTXKgmYOLe6dB0gCmAVtuRScE1hymQFl4hpg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-uri-escape@4.2.2':
@@ -4751,8 +4854,15 @@ packages:
   fast-xml-builder@1.1.3:
     resolution: {integrity: sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==}
 
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
   fast-xml-parser@5.4.1:
     resolution: {integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==}
+    hasBin: true
+
+  fast-xml-parser@5.5.8:
+    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
     hasBin: true
 
   fastq@1.20.1:
@@ -6500,6 +6610,10 @@ packages:
 
   path-expression-matcher@1.1.3:
     resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
+    engines: {node: '>=14.0.0'}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
@@ -8750,6 +8864,22 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.18
+      '@smithy/core': 3.23.15
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
   '@aws-sdk/crc64-nvme@3.972.5':
     dependencies:
       '@smithy/types': 4.13.1
@@ -8937,6 +9067,23 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-s3@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.15
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.23
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-ssec@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -9005,6 +9152,26 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/s3-request-presigner@3.1031.0':
+    dependencies:
+      '@aws-sdk/signature-v4-multi-region': 3.996.17
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-format-url': 3.972.10
+      '@smithy/middleware-endpoint': 4.4.30
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.17':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.29
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.8':
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.20
@@ -9031,6 +9198,11 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/util-arn-parser@3.972.3':
     dependencies:
       tslib: 2.8.1
@@ -9041,6 +9213,13 @@ snapshots:
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
       '@smithy/util-endpoints': 3.3.3
+      tslib: 2.8.1
+
+  '@aws-sdk/util-format-url@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.5':
@@ -9067,6 +9246,12 @@ snapshots:
     dependencies:
       '@smithy/types': 4.13.1
       fast-xml-parser: 5.4.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.18':
+    dependencies:
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.5.8
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -11384,6 +11569,19 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/core@3.23.15':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.23
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.12':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
@@ -11427,6 +11625,14 @@ snapshots:
       '@smithy/protocol-http': 5.3.12
       '@smithy/querystring-builder': 4.2.12
       '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
@@ -11486,6 +11692,17 @@ snapshots:
       '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
 
+  '@smithy/middleware-endpoint@4.4.30':
+    dependencies:
+      '@smithy/core': 3.23.15
+      '@smithy/middleware-serde': 4.2.18
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
   '@smithy/middleware-retry@4.4.42':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
@@ -11505,9 +11722,21 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/middleware-serde@4.2.18':
+    dependencies:
+      '@smithy/core': 3.23.15
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/middleware-stack@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.3.12':
@@ -11515,6 +11744,13 @@ snapshots:
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.14':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.4.16':
@@ -11525,14 +11761,31 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.5.3':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/property-provider@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/protocol-http@5.3.12':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/querystring-builder@4.2.12':
@@ -11541,9 +11794,20 @@ snapshots:
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/querystring-builder@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
   '@smithy/querystring-parser@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/service-error-classification@4.2.12':
@@ -11555,6 +11819,11 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/shared-ini-file-loader@4.4.9':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/signature-v4@5.3.12':
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
@@ -11564,6 +11833,27 @@ snapshots:
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-uri-escape': 4.2.2
       '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.14':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.11':
+    dependencies:
+      '@smithy/core': 3.23.15
+      '@smithy/middleware-endpoint': 4.4.30
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.23
       tslib: 2.8.1
 
   '@smithy/smithy-client@4.12.5':
@@ -11580,10 +11870,20 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@smithy/url-parser@4.2.12':
     dependencies:
       '@smithy/querystring-parser': 4.2.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.14':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-base64@4.3.2':
@@ -11646,6 +11946,11 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/util-middleware@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/util-retry@4.2.12':
     dependencies:
       '@smithy/service-error-classification': 4.2.12
@@ -11657,6 +11962,17 @@ snapshots:
       '@smithy/fetch-http-handler': 5.3.15
       '@smithy/node-http-handler': 4.4.16
       '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.23':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.5.3
+      '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-hex-encoding': 4.2.2
@@ -14290,9 +14606,19 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.1.3
 
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
   fast-xml-parser@5.4.1:
     dependencies:
       fast-xml-builder: 1.1.3
+      strnum: 2.2.0
+
+  fast-xml-parser@5.5.8:
+    dependencies:
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
       strnum: 2.2.0
 
   fastq@1.20.1:
@@ -16193,6 +16519,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.1.3: {}
+
+  path-expression-matcher@1.5.0: {}
 
   path-is-absolute@1.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,7 +165,11 @@ importers:
         specifier: ^5
         version: 5.9.3
 
-  packages/shared: {}
+  packages/shared:
+    devDependencies:
+      typescript:
+        specifier: ^5
+        version: 5.9.3
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,9 +139,6 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.888.0
         version: 3.1009.0
-      '@aws-sdk/s3-request-presigner':
-        specifier: ^3.888.0
-        version: 3.1031.0
       '@smithy/hash-node':
         specifier: ^4.2.12
         version: 4.2.12
@@ -256,10 +253,6 @@ packages:
     resolution: {integrity: sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.974.0':
-    resolution: {integrity: sha512-8j+dMtyDqNXFmi09CBdz8TY6Ltf2jhfHuP6ZvG4zVjndRc6JF0aeBUbRwQLndbptFCsdctRQgdNWecy4TIfXAw==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/crc64-nvme@3.972.5':
     resolution: {integrity: sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==}
     engines: {node: '>=20.0.0'}
@@ -328,10 +321,6 @@ packages:
     resolution: {integrity: sha512-yhva/xL5H4tWQgsBjwV+RRD0ByCzg0TcByDCLp3GXdn/wlyRNfy8zsswDtCvr1WSKQkSQYlyEzPuWkJG0f5HvQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-sdk-s3@3.972.29':
-    resolution: {integrity: sha512-ayk68penP1WDZmyDZVeUQzq+HI3iDq5xezohUxIQoKFKE0KdCnDcxLCNnLanhBfgQDaKiGHVXhxZMDWJAEEBsQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/middleware-ssec@3.972.8':
     resolution: {integrity: sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==}
     engines: {node: '>=20.0.0'}
@@ -348,14 +337,6 @@ packages:
     resolution: {integrity: sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/s3-request-presigner@3.1031.0':
-    resolution: {integrity: sha512-mM7Qx3NEQvX2dKGFxRaE/SSSiiBqRszSGpLPsNHJQNCBhlrm6/H7Vf0s/wTHZcWcM9GCJKZj46DLuOSKT1GKCA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.996.17':
-    resolution: {integrity: sha512-qDwhXw+SIM5vMAMgflA8LPRa7xP+/wgXYr++llzCOwp7kkM2v7GGGWzoRW8e1CACaO4ljZd/NSQbsRLKm1sMWw==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/signature-v4-multi-region@3.996.8':
     resolution: {integrity: sha512-n1qYFD+tbqZuyskVaxUE+t10AUz9g3qzDw3Tp6QZDKmqsjfDmZBd4GIk2EKJJNtcCBtE5YiUjDYA+3djFAFBBg==}
     engines: {node: '>=20.0.0'}
@@ -368,20 +349,12 @@ packages:
     resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/types@3.973.8':
-    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/util-arn-parser@3.972.3':
     resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-endpoints@3.996.5':
     resolution: {integrity: sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-format-url@3.972.10':
-    resolution: {integrity: sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.5':
@@ -402,10 +375,6 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.11':
     resolution: {integrity: sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/xml-builder@3.972.18':
-    resolution: {integrity: sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -2528,10 +2497,6 @@ packages:
     resolution: {integrity: sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/core@3.23.15':
-    resolution: {integrity: sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/credential-provider-imds@4.2.12':
     resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
     engines: {node: '>=18.0.0'}
@@ -2558,10 +2523,6 @@ packages:
 
   '@smithy/fetch-http-handler@5.3.15':
     resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/fetch-http-handler@5.3.17':
-    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.2.13':
@@ -2600,10 +2561,6 @@ packages:
     resolution: {integrity: sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-endpoint@4.4.30':
-    resolution: {integrity: sha512-qS2XqhKeXmdZ4nEQ4cOxIczSP/Y91wPAHYuRwmWDCh975B7/57uxsm5d6sisnUThn2u2FwzMdJNM7AbO1YPsPg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/middleware-retry@4.4.42':
     resolution: {integrity: sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==}
     engines: {node: '>=18.0.0'}
@@ -2612,40 +2569,20 @@ packages:
     resolution: {integrity: sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-serde@4.2.18':
-    resolution: {integrity: sha512-M6CSgnp3v4tYz9ynj2JHbA60woBZcGqEwNjTKjBsNHPV26R1ZX52+0wW8WsZU18q45jD0tw2wL22S17Ze9LpEw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/middleware-stack@4.2.12':
     resolution: {integrity: sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-stack@4.2.14':
-    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-config-provider@4.3.12':
     resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-config-provider@4.3.14':
-    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/node-http-handler@4.4.16':
     resolution: {integrity: sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-http-handler@4.5.3':
-    resolution: {integrity: sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/property-provider@4.2.12':
     resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/property-provider@4.2.14':
-    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/protocol-http@5.3.14':
@@ -2656,16 +2593,8 @@ packages:
     resolution: {integrity: sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/querystring-builder@4.2.14':
-    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/querystring-parser@4.2.12':
     resolution: {integrity: sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-parser@4.2.14':
-    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/service-error-classification@4.2.12':
@@ -2676,16 +2605,8 @@ packages:
     resolution: {integrity: sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/shared-ini-file-loader@4.4.9':
-    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/signature-v4@5.3.14':
     resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/smithy-client@4.12.11':
-    resolution: {integrity: sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.12.5':
@@ -2702,10 +2623,6 @@ packages:
 
   '@smithy/url-parser@4.2.12':
     resolution: {integrity: sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/url-parser@4.2.14':
-    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-base64@4.3.2':
@@ -2762,10 +2679,6 @@ packages:
 
   '@smithy/util-stream@4.5.19':
     resolution: {integrity: sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-stream@4.5.23':
-    resolution: {integrity: sha512-N6on1+ngJ3RznZOnDWNveIwnTSlqxNnXuNAh7ez889ZZaRdXoNRTXKgmYOLe6dB0gCmAVtuRScE1hymQFl4hpg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-uri-escape@4.2.2':
@@ -4855,15 +4768,8 @@ packages:
   fast-xml-builder@1.1.3:
     resolution: {integrity: sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==}
 
-  fast-xml-builder@1.1.5:
-    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
-
   fast-xml-parser@5.4.1:
     resolution: {integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==}
-    hasBin: true
-
-  fast-xml-parser@5.5.8:
-    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
     hasBin: true
 
   fastq@1.20.1:
@@ -6611,10 +6517,6 @@ packages:
 
   path-expression-matcher@1.1.3:
     resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
-    engines: {node: '>=14.0.0'}
-
-  path-expression-matcher@1.5.0:
-    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
@@ -8865,22 +8767,6 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/core@3.974.0':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/xml-builder': 3.972.18
-      '@smithy/core': 3.23.15
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
-      '@smithy/smithy-client': 4.12.11
-      '@smithy/types': 4.14.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
   '@aws-sdk/crc64-nvme@3.972.5':
     dependencies:
       '@smithy/types': 4.13.1
@@ -9068,23 +8954,6 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-s3@3.972.29':
-    dependencies:
-      '@aws-sdk/core': 3.974.0
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-arn-parser': 3.972.3
-      '@smithy/core': 3.23.15
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
-      '@smithy/smithy-client': 4.12.11
-      '@smithy/types': 4.14.1
-      '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-stream': 4.5.23
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
   '@aws-sdk/middleware-ssec@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -9153,26 +9022,6 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/s3-request-presigner@3.1031.0':
-    dependencies:
-      '@aws-sdk/signature-v4-multi-region': 3.996.17
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-format-url': 3.972.10
-      '@smithy/middleware-endpoint': 4.4.30
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.11
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/signature-v4-multi-region@3.996.17':
-    dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.972.29
-      '@aws-sdk/types': 3.973.8
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
   '@aws-sdk/signature-v4-multi-region@3.996.8':
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.20
@@ -9199,11 +9048,6 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/types@3.973.8':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
   '@aws-sdk/util-arn-parser@3.972.3':
     dependencies:
       tslib: 2.8.1
@@ -9214,13 +9058,6 @@ snapshots:
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
       '@smithy/util-endpoints': 3.3.3
-      tslib: 2.8.1
-
-  '@aws-sdk/util-format-url@3.972.10':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/querystring-builder': 4.2.14
-      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.5':
@@ -9247,12 +9084,6 @@ snapshots:
     dependencies:
       '@smithy/types': 4.13.1
       fast-xml-parser: 5.4.1
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.18':
-    dependencies:
-      '@smithy/types': 4.14.1
-      fast-xml-parser: 5.5.8
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -11570,19 +11401,6 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
-  '@smithy/core@3.23.15':
-    dependencies:
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-stream': 4.5.23
-      '@smithy/util-utf8': 4.2.2
-      '@smithy/uuid': 1.1.2
-      tslib: 2.8.1
-
   '@smithy/credential-provider-imds@4.2.12':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
@@ -11626,14 +11444,6 @@ snapshots:
       '@smithy/protocol-http': 5.3.14
       '@smithy/querystring-builder': 4.2.12
       '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
-      tslib: 2.8.1
-
-  '@smithy/fetch-http-handler@5.3.17':
-    dependencies:
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/querystring-builder': 4.2.14
-      '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
@@ -11693,17 +11503,6 @@ snapshots:
       '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
 
-  '@smithy/middleware-endpoint@4.4.30':
-    dependencies:
-      '@smithy/core': 3.23.15
-      '@smithy/middleware-serde': 4.2.18
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-middleware': 4.2.14
-      tslib: 2.8.1
-
   '@smithy/middleware-retry@4.4.42':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
@@ -11723,21 +11522,9 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/middleware-serde@4.2.18':
-    dependencies:
-      '@smithy/core': 3.23.15
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
   '@smithy/middleware-stack@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/middleware-stack@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.3.12':
@@ -11745,13 +11532,6 @@ snapshots:
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/node-config-provider@4.3.14':
-    dependencies:
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.4.16':
@@ -11762,21 +11542,9 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.5.3':
-    dependencies:
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/querystring-builder': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
   '@smithy/property-provider@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/property-provider@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/protocol-http@5.3.14':
@@ -11790,20 +11558,9 @@ snapshots:
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/querystring-builder@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      '@smithy/util-uri-escape': 4.2.2
-      tslib: 2.8.1
-
   '@smithy/querystring-parser@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/querystring-parser@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/service-error-classification@4.2.12':
@@ -11815,11 +11572,6 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/shared-ini-file-loader@4.4.9':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
   '@smithy/signature-v4@5.3.14':
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
@@ -11829,16 +11581,6 @@ snapshots:
       '@smithy/util-middleware': 4.2.14
       '@smithy/util-uri-escape': 4.2.2
       '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/smithy-client@4.12.11':
-    dependencies:
-      '@smithy/core': 3.23.15
-      '@smithy/middleware-endpoint': 4.4.30
-      '@smithy/middleware-stack': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-stream': 4.5.23
       tslib: 2.8.1
 
   '@smithy/smithy-client@4.12.5':
@@ -11863,12 +11605,6 @@ snapshots:
     dependencies:
       '@smithy/querystring-parser': 4.2.12
       '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/url-parser@4.2.14':
-    dependencies:
-      '@smithy/querystring-parser': 4.2.14
-      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-base64@4.3.2':
@@ -11947,17 +11683,6 @@ snapshots:
       '@smithy/fetch-http-handler': 5.3.15
       '@smithy/node-http-handler': 4.4.16
       '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-stream@4.5.23':
-    dependencies:
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.5.3
-      '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-hex-encoding': 4.2.2
@@ -14591,19 +14316,9 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.1.3
 
-  fast-xml-builder@1.1.5:
-    dependencies:
-      path-expression-matcher: 1.5.0
-
   fast-xml-parser@5.4.1:
     dependencies:
       fast-xml-builder: 1.1.3
-      strnum: 2.2.0
-
-  fast-xml-parser@5.5.8:
-    dependencies:
-      fast-xml-builder: 1.1.5
-      path-expression-matcher: 1.5.0
       strnum: 2.2.0
 
   fastq@1.20.1:
@@ -16504,8 +16219,6 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.1.3: {}
-
-  path-expression-matcher@1.5.0: {}
 
   path-is-absolute@1.0.1: {}
 


### PR DESCRIPTION
## Summary

补齐管理后台依赖的 8 个后端接口、新增 `memberships` 表 + seed 脚本，让前端彻底去掉"本地拼凑/demo 兜底"逻辑。

- **新增路由**（都走 `X-Admin-Key` 鉴权）
  - `GET /api/admin/devices` 统一设备列表（扁平 UNION ALL + keyword/model/imageStatus/bindingStatus/species/status/sort/page/pageSize）
  - `GET /api/admin/devices/:type/:id/detail` 设备详情（绑定宠物、陪伴天数、关联设备、定制进度）
  - `GET /api/admin/customization/tasks` 定制任务列表摘要（真实 base/personalized 计数、categoryStatus、defaultPreviewUrl）
  - `POST /api/admin/uploads/presign` 预签名 PUT URL（image/jpeg|png|webp 白名单，Content-Type 参与签名）
  - `GET /api/admin/users/:id/membership` / `PUT /api/admin/users/:id/membership`（事务内同步 `users.avatarQuota`）
  - `GET /api/admin/avatar-review/stats` 单 SQL 返回四项真实口径统计
- **数据层**
  - 新 `memberships` 表 + `membership_level` / `membership_status` enum + 补查询索引
  - `packages/shared` 新增 Membership / AdminDevice* / CustomizationTask / AvatarReviewStats / PresignResponse 契约
  - 通用分页工具 `utils/pagination.ts`
- **Seed**
  - `pnpm -F server db:seed:demo` 造 20 users / 30 pets / 25 collars / 15 desktops / 40 avatars / 15 memberships，可重复执行

规格文档：`docs/specs/260417-admin-backend-completion/`（requirements / design / review / review-final / reflection）。

## Test plan

- [x] `pnpm -F shared build` / `pnpm -F server typecheck` / `pnpm -F server build`
- [x] `pnpm db:migrate` 本地 PG 执行成功
- [x] `pnpm -F server db:seed:demo` 首次 + 第二次执行，desktop 绑定计数保持稳定
- [x] `GET /api/admin/devices` 跨 collar/desktop 搜索、扁平分页
- [x] `GET /api/admin/devices/:type/:id/detail` 返回 avatarProgress / relatedDevices
- [x] `GET /api/admin/customization/tasks` 真实 base/personalized 计数（去重）
- [x] `POST /api/admin/uploads/presign` 正确 Content-Type 可 PUT、错误 Content-Type 返回 403
- [x] `PUT /api/admin/users/:id/membership` upsert 后 `users.avatarQuota` 同步
- [x] `GET /api/admin/avatar-review/stats` 四项数值合理
- [x] 无 `X-Admin-Key` 时所有新路由返回 401
- [x] 老 `/collars`、`/desktops`、`/avatars` 接口行为未变

🤖 Generated with [Claude Code](https://claude.com/claude-code)