### PR TITLE
fix: 统一 MAC 归一化 & 恢复侧栏设备管理入口

### DIFF
--- a/packages/admin/src/App.tsx
+++ b/packages/admin/src/App.tsx
@@ -50,6 +50,8 @@ const menuItems: MenuProps["items"] = [
     label: "开发工具",
     children: [
       { key: "/pets", icon: <HeartOutlined />, label: "宠物管理" },
+      { key: "/collars", icon: <MobileOutlined />, label: "项圈管理" },
+      { key: "/desktops", icon: <MobileOutlined />, label: "桌面端管理" },
       { key: "/events", icon: <ThunderboltOutlined />, label: "模拟事件" },
     ],
   },

--- a/packages/server/src/routes/admin/devices.ts
+++ b/packages/server/src/routes/admin/devices.ts
@@ -14,8 +14,27 @@ import { ALL_ACTIONS } from "shared";
 import { db } from "../../db";
 import { users, pets, collarDevices, desktopDevices, desktopPetBindings, petAvatars, petBehaviors } from "../../db/schema";
 import { createId } from "../../utils/id";
+import { normalizeMac, NORMALIZED_MAC_REGEX } from "../../utils/mac";
 import { buildPageResponse, parsePagination } from "../../utils/pagination";
 import { pick } from "./utils";
+
+function normalizeMacOrError(raw: unknown): { ok: true; mac: string } | { ok: false; error: string } {
+  if (typeof raw !== "string" || !raw.trim()) {
+    return { ok: false, error: "macAddress is required" };
+  }
+  const mac = normalizeMac(raw);
+  if (!NORMALIZED_MAC_REGEX.test(mac)) {
+    return { ok: false, error: "Invalid macAddress format" };
+  }
+  return { ok: true, mac };
+}
+
+function randomMac(): string {
+  const hex = "0123456789ABCDEF";
+  let out = "";
+  for (let i = 0; i < 12; i++) out += hex[Math.floor(Math.random() * 16)];
+  return out;
+}
 
 async function validateCollarPetBinding(collarDeviceId: string, petId: string) {
   const [collar] = await db.select().from(collarDevices).where(eq(collarDevices.id, collarDeviceId));
@@ -580,12 +599,22 @@ devicesRoute.get("/collars", async (c) => {
 
 devicesRoute.post("/collars", async (c) => {
   const body = await c.req.json();
+
+  let macAddress: string;
+  if (body.macAddress === undefined || body.macAddress === null || body.macAddress === "") {
+    macAddress = randomMac();
+  } else {
+    const check = normalizeMacOrError(body.macAddress);
+    if (!check.ok) return c.json({ error: check.error }, 400);
+    macAddress = check.mac;
+  }
+
   const [collar] = await db
     .insert(collarDevices)
     .values({
       userId: body.userId ?? null,
       name: body.name?.trim() || "未命名项圈",
-      macAddress: body.macAddress ?? `MOCK:${createId().slice(0, 11).replace(/(.{2})/g, "$1:").slice(0, 17)}`,
+      macAddress,
       petId: body.userId ? (body.petId ?? null) : null,
       status: body.status ?? "offline",
       battery: body.battery ?? 100,
@@ -600,6 +629,11 @@ devicesRoute.put("/collars/:id", async (c) => {
   const id = c.req.param("id");
   const body = await c.req.json();
   const allowed = pick(body, ["name", "macAddress", "petId", "status", "battery", "signal", "firmwareVersion", "userId"]);
+  if (allowed.macAddress !== undefined) {
+    const check = normalizeMacOrError(allowed.macAddress);
+    if (!check.ok) return c.json({ error: check.error }, 400);
+    allowed.macAddress = check.mac;
+  }
   const [collar] = await db
     .update(collarDevices)
     .set({ ...allowed, updatedAt: new Date() })
@@ -667,12 +701,22 @@ devicesRoute.get("/desktops", async (c) => {
 
 devicesRoute.post("/desktops", async (c) => {
   const body = await c.req.json();
+
+  let macAddress: string;
+  if (body.macAddress === undefined || body.macAddress === null || body.macAddress === "") {
+    macAddress = randomMac();
+  } else {
+    const check = normalizeMacOrError(body.macAddress);
+    if (!check.ok) return c.json({ error: check.error }, 400);
+    macAddress = check.mac;
+  }
+
   const [desktop] = await db
     .insert(desktopDevices)
     .values({
       userId: body.userId ?? null,
       name: body.name?.trim() || "未命名桌面端",
-      macAddress: body.macAddress ?? `MOCK:${createId().slice(0, 11).replace(/(.{2})/g, "$1:").slice(0, 17)}`,
+      macAddress,
       status: body.status ?? "offline",
       firmwareVersion: body.firmwareVersion ?? "1.0.0",
     })
@@ -684,6 +728,11 @@ devicesRoute.put("/desktops/:id", async (c) => {
   const id = c.req.param("id");
   const body = await c.req.json();
   const allowed = pick(body, ["name", "macAddress", "status", "firmwareVersion", "userId"]);
+  if (allowed.macAddress !== undefined) {
+    const check = normalizeMacOrError(allowed.macAddress);
+    if (!check.ok) return c.json({ error: check.error }, 400);
+    allowed.macAddress = check.mac;
+  }
   const [desktop] = await db
     .update(desktopDevices)
     .set({ ...allowed, updatedAt: new Date() })

--- a/packages/server/src/routes/device-report.ts
+++ b/packages/server/src/routes/device-report.ts
@@ -3,6 +3,7 @@ import { and, desc, eq, isNull } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 import { db } from "../db";
+import { normalizeMac, NORMALIZED_MAC_REGEX } from "../utils/mac";
 import {
   collarDevices,
   desktopDevices,
@@ -13,7 +14,6 @@ import {
 
 const deviceReportRoute = new Hono();
 
-const NORMALIZED_MAC_REGEX = /^[0-9A-F]{12}$/;
 const deviceTypeSchema = z.enum(["collar", "desktop"]);
 const deviceStatusSchema = z.enum(["online", "offline", "pairing"]);
 const isoDatetimeSchema = z
@@ -49,10 +49,6 @@ const eventBodySchema = z.object({
   actionType: z.string().trim().min(1).max(64),
   occurredAt: isoDatetimeSchema.optional(),
 });
-
-function normalizeMac(mac: string): string {
-  return mac.replace(/[:\-\s]/g, "").toUpperCase();
-}
 
 function toIsoString(value: Date | string | null | undefined): string | null {
   if (!value) {

--- a/packages/server/src/routes/devices.ts
+++ b/packages/server/src/routes/devices.ts
@@ -13,6 +13,7 @@ import {
 } from "../db/schema";
 import { eq, and, isNull, desc } from "drizzle-orm";
 import { generateInviteCode, verifyInviteCode } from "../utils/invite";
+import { normalizeMac, NORMALIZED_MAC_REGEX } from "../utils/mac";
 import { deviceTypeSchema } from "../validators/user-end";
 
 const devicesRoute = new Hono();
@@ -20,12 +21,6 @@ const devicesRoute = new Hono();
 function getInviteCodeHash(code: string): string {
   return createHash("sha256").update(code).digest("hex");
 }
-
-function normalizeMac(mac: string): string {
-  return mac.replace(/[:\-\s]/g, "").toUpperCase();
-}
-
-const NORMALIZED_MAC_REGEX = /^[0-9A-F]{12}$/;
 
 async function findCollarByMac(macAddress: string) {
   const [collar] = await db

--- a/packages/server/src/utils/mac.ts
+++ b/packages/server/src/utils/mac.ts
@@ -1,0 +1,5 @@
+export const NORMALIZED_MAC_REGEX = /^[0-9A-F]{12}$/;
+
+export function normalizeMac(mac: string): string {
+  return mac.replace(/[:\-\s]/g, "").toUpperCase();
+}


### PR DESCRIPTION
## Summary
- **后端**：抽出 `packages/server/src/utils/mac.ts`（`normalizeMac` + `NORMALIZED_MAC_REGEX`），让 `devices.ts`、`device-report.ts`、`admin/devices.ts` 共用
- **后端**：admin 创建 / 更新 collar & desktop 时入库前归一化 MAC，非法格式返回 400；留空自动生成改为纯 12-hex（之前是 `MOCK:...` 带冒号，跟硬件上报的归一化格式对不上）
- **前端**：admin 侧栏"开发工具"分组补回"项圈管理"、"桌面端管理"两个入口。新版聚合 `/devices` 页面没有新建按钮，目前只能走这两个老页面创建模拟设备

## Background
PR #61 落地硬件上报接口后发现 admin 手建的设备 MAC 带冒号，硬件按 12-hex 上报会 404。这次统一。

## Test plan
- [x] `pnpm --filter server test` 125/126（唯一失败是 main 已有的 `pets.test.ts::todayCount` 时区问题）
- [x] `pnpm --filter admin build` 无 TS 错
- [ ] 部署后在 admin UI `/collars` 页面用带冒号 MAC 创建，确认存库变 12-hex

🤖 Generated with [Claude Code](https://claude.com/claude-code)