### PR TITLE
feat: 管理后台对齐最新接口并补齐页面联调

### DIFF
--- a/packages/admin/src/api/client.ts
+++ b/packages/admin/src/api/client.ts
@@ -1,3 +1,20 @@
+import type {
+  AdminDeviceDetail,
+  AdminDeviceListItem,
+  AvatarReviewStats,
+  CustomizationTask,
+  DeviceType,
+  Membership,
+  PresignResponse,
+} from "shared";
+
+type PageResponse<T> = {
+  items: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
 export function getAdminKey() {
   return localStorage.getItem("adminKey") || "";
 }
@@ -109,6 +126,17 @@ export const api = {
   // Enhanced Users
   getEnhancedUsers: () => request<{ users: any[] }>("/users/enhanced"),
   getUserDetail: (id: string) => request<any>(`/users/${id}/detail`),
+  getMembership: (id: string) => request<Membership>(`/users/${id}/membership`),
+  updateMembership: (
+    id: string,
+    data: {
+      level: Membership["level"];
+      status?: Membership["status"];
+      expireAt?: string | null;
+      benefits?: Membership["benefits"];
+      avatarQuotaTotal?: number;
+    },
+  ) => request<Membership>(`/users/${id}/membership`, { method: "PUT", body: JSON.stringify(data) }),
 
   // Enhanced Devices (with filters)
   getFilteredCollars: (params?: Record<string, string>) => {
@@ -119,4 +147,25 @@ export const api = {
     const qs = params ? "?" + new URLSearchParams(params).toString() : "";
     return request<{ desktops: any[] }>(`/desktops${qs}`);
   },
+  getDevices: (params?: Record<string, string>) => {
+    const qs = params ? `?${new URLSearchParams(params).toString()}` : "";
+    return request<PageResponse<AdminDeviceListItem>>(`/devices${qs}`);
+  },
+  getDeviceDetail: (type: DeviceType, id: string) => request<AdminDeviceDetail>(`/devices/${type}/${id}/detail`),
+
+  // Avatar Review
+  getAvatarReviewStats: () => request<AvatarReviewStats>("/avatar-review/stats"),
+
+  // Customization
+  getCustomizationTasks: (params?: Record<string, string>) => {
+    const qs = params ? `?${new URLSearchParams(params).toString()}` : "";
+    return request<PageResponse<CustomizationTask>>(`/customization/tasks${qs}`);
+  },
+
+  // Uploads
+  createUploadPresign: (contentType: "image/jpeg" | "image/png" | "image/webp") =>
+    request<PresignResponse>("/uploads/presign", {
+      method: "POST",
+      body: JSON.stringify({ contentType }),
+    }),
 };

--- a/packages/admin/src/pages/Customization.tsx
+++ b/packages/admin/src/pages/Customization.tsx
@@ -20,6 +20,7 @@ import {
   BASIC_ACTIONS,
   FUN_ACTIONS,
   type ActionType,
+  type CustomizationTask,
   type Gender,
   type Pet,
   type PetAvatar,
@@ -43,6 +44,7 @@ type CustomizationAvatar = PetAvatar & {
       })
     | null;
   user: Pick<User, "id" | "nickname" | "avatarUrl" | "wechatOpenid" | "phone"> | null;
+  task?: CustomizationTask | null;
 };
 
 type CustomizationAvatarDetail = CustomizationAvatar & {
@@ -57,6 +59,8 @@ type CategoryProgress = {
   completed: number;
   total: number;
 };
+
+type UploadContentType = "image/jpeg" | "image/png" | "image/webp";
 
 const TASK_STATUSES: CustomizationStatus[] = ["approved", "processing", "done"];
 
@@ -216,6 +220,108 @@ function getDefaultPreviewActionType(actions: PetAvatarAction[]) {
   return actions[0].actionType as ActionType;
 }
 
+function toCustomizationTaskSummary(avatar: CustomizationAvatarDetail): CustomizationTask {
+  const baseActionCount = countCompletedActions(avatar.actions, BASIC_ACTIONS);
+  const personalizedActionCount = countCompletedActions(avatar.actions, FUN_ACTIONS);
+  const totalActionCount = avatar.actions.length;
+
+  return {
+    avatarId: avatar.id,
+    petId: avatar.petId,
+    petName: avatar.pet?.name ?? "未命名宠物",
+    petSpecies: (avatar.pet?.species === "dog" ? "dog" : "cat") as Species,
+    userId: avatar.user?.id ?? "demo-user",
+    userNickname: avatar.user?.nickname ?? "未知微信用户",
+    status: avatar.status,
+    defaultPreviewUrl: avatar.actions[0]?.imageUrl ?? avatar.sourceImageUrl,
+    baseActionCount,
+    personalizedActionCount,
+    totalActionCount,
+    baseActionTotal: BASIC_ACTIONS.length,
+    personalizedActionTotal: FUN_ACTIONS.length,
+    categoryStatus:
+      totalActionCount === 0
+        ? "empty"
+        : totalActionCount >= BASIC_ACTIONS.length + FUN_ACTIONS.length
+          ? "all_done"
+          : baseActionCount > 0
+            ? "base_done"
+            : "partial",
+    isNewToday: enteredCustomizationToday(avatar),
+    createdAt: avatar.createdAt,
+    reviewedAt: avatar.reviewedAt ?? null,
+  };
+}
+
+function createTaskPreview(task: CustomizationTask) {
+  return buildMockImageUrl(task.petName, "#91caff", `${task.userNickname} · 定制任务`);
+}
+
+function mergeTasksWithAvatarSummaries(
+  tasks: CustomizationTask[],
+  avatarSummaries: CustomizationAvatar[],
+): CustomizationAvatar[] {
+  const avatarMap = new Map(avatarSummaries.map((avatar) => [avatar.id, avatar]));
+
+  return tasks.map((task) => {
+    const avatar = avatarMap.get(task.avatarId);
+    return {
+      id: task.avatarId,
+      petId: task.petId,
+      sourceImageUrl: avatar?.sourceImageUrl ?? task.defaultPreviewUrl ?? createTaskPreview(task),
+      status: task.status,
+      rejectReason: avatar?.rejectReason ?? null,
+      reviewedAt: task.reviewedAt ?? avatar?.reviewedAt ?? null,
+      createdAt: task.createdAt,
+      pet:
+        avatar?.pet ??
+        ({
+          id: task.petId,
+          name: task.petName,
+          species: task.petSpecies,
+          breed: null,
+          gender: "unknown",
+          birthday: null,
+        } satisfies CustomizationAvatar["pet"]),
+      user:
+        avatar?.user ??
+        {
+          id: task.userId,
+          nickname: task.userNickname,
+          avatarUrl: null,
+          wechatOpenid: null,
+          phone: null,
+        },
+      task,
+    };
+  });
+}
+
+function getTaskProgress(task: CustomizationTask | null | undefined, category: CategoryFilter): CategoryProgress | null {
+  if (!task) {
+    return null;
+  }
+
+  if (category === "basic") {
+    return {
+      completed: task.baseActionCount,
+      total: task.baseActionTotal,
+    };
+  }
+
+  if (category === "fun") {
+    return {
+      completed: task.personalizedActionCount,
+      total: task.personalizedActionTotal,
+    };
+  }
+
+  return {
+    completed: task.totalActionCount,
+    total: task.baseActionTotal + task.personalizedActionTotal,
+  };
+}
+
 function buildMockImageUrl(title: string, accent: string, subtitle: string) {
   const svg = `
     <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1200" viewBox="0 0 1200 1200">
@@ -240,7 +346,10 @@ function buildMockImageUrl(title: string, accent: string, subtitle: string) {
 
 function toCustomizationAvatarSummary(avatar: CustomizationAvatarDetail): CustomizationAvatar {
   const { actions: _actions, ...summary } = avatar;
-  return summary;
+  return {
+    ...summary,
+    task: toCustomizationTaskSummary(avatar),
+  };
 }
 
 function createMockCustomizationDetails(): CustomizationAvatarDetail[] {
@@ -380,6 +489,9 @@ export default function Customization() {
   const [demoAvatarDetails, setDemoAvatarDetails] = useState<CustomizationAvatarDetail[]>(() => initialDemoDetails);
   const [isDemoMode, setIsDemoMode] = useState(true);
   const [loading, setLoading] = useState(false);
+  const [todayNewPendingCount, setTodayNewPendingCount] = useState(
+    initialDemoDetails.filter((avatar) => enteredCustomizationToday(avatar)).length,
+  );
   const [taskTab, setTaskTab] = useState<TaskTab>("pending");
   const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>("all");
   const [selectedAvatarId, setSelectedAvatarId] = useState<string | null>(null);
@@ -389,6 +501,8 @@ export default function Customization() {
   const [uploadModalOpen, setUploadModalOpen] = useState(false);
   const [uploadActionType, setUploadActionType] = useState<ActionType | null>(null);
   const [uploadImageUrl, setUploadImageUrl] = useState("");
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
+  const [uploadPreviewUrl, setUploadPreviewUrl] = useState("");
   const [submittingAction, setSubmittingAction] = useState(false);
   const [deletingActionId, setDeletingActionId] = useState<string | null>(null);
   const [syncing, setSyncing] = useState(false);
@@ -398,13 +512,31 @@ export default function Customization() {
     setLoading(true);
 
     try {
-      const response = await api.getAvatars();
-      const nextAvatars = ((response.avatars as CustomizationAvatar[]) ?? []).filter((avatar) =>
+      const [tasksResponse, pendingBadgeResponse, avatarResponse] = await Promise.all([
+        api.getCustomizationTasks({
+          page: "1",
+          pageSize: "100",
+          status: "approved,processing,done",
+          category: "all",
+        }),
+        api.getCustomizationTasks({
+          page: "1",
+          pageSize: "100",
+          status: "approved,processing",
+          category: "all",
+        }),
+        api.getAvatars(),
+      ]);
+
+      const nextAvatarSummaries = ((avatarResponse.avatars as CustomizationAvatar[]) ?? []).filter((avatar) =>
         TASK_STATUSES.includes(avatar.status as CustomizationStatus),
       );
+      const nextAvatars = mergeTasksWithAvatarSummaries(tasksResponse.items ?? [], nextAvatarSummaries);
+      const pendingTasks = pendingBadgeResponse.items ?? [];
 
       if (nextAvatars.length === 0) {
-        applyDemoDataState(setDemoAvatarDetails, setAvatars, setIsDemoMode);
+        const demoDetails = applyDemoDataState(setDemoAvatarDetails, setAvatars, setIsDemoMode);
+        setTodayNewPendingCount(demoDetails.filter((avatar) => enteredCustomizationToday(avatar)).length);
         messageApi.warning("未获取到真实定制任务，当前展示演示数据");
         return;
       }
@@ -412,8 +544,10 @@ export default function Customization() {
       setIsDemoMode(false);
       setDemoAvatarDetails([]);
       setAvatars(nextAvatars);
+      setTodayNewPendingCount(pendingTasks.filter((task) => task.isNewToday).length);
     } catch (error) {
-      applyDemoDataState(setDemoAvatarDetails, setAvatars, setIsDemoMode);
+      const demoDetails = applyDemoDataState(setDemoAvatarDetails, setAvatars, setIsDemoMode);
+      setTodayNewPendingCount(demoDetails.filter((avatar) => enteredCustomizationToday(avatar)).length);
       messageApi.warning("定制任务加载失败，当前展示演示数据");
     } finally {
       setLoading(false);
@@ -472,27 +606,34 @@ export default function Customization() {
   };
 
   useEffect(() => {
+    if (uploadImageUrl.trim()) {
+      setUploadPreviewUrl(uploadImageUrl.trim());
+      return;
+    }
+
+    if (!uploadFile) {
+      setUploadPreviewUrl("");
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(uploadFile);
+    setUploadPreviewUrl(objectUrl);
+
+    return () => {
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [uploadFile, uploadImageUrl]);
+
+  useEffect(() => {
     void loadAvatars();
   }, []);
 
-  const pendingAvatars = useMemo(
-    () => avatars.filter((avatar) => avatar.status === "approved" || avatar.status === "processing"),
-    [avatars],
-  );
-
-  const doneAvatars = useMemo(
-    () => avatars.filter((avatar) => avatar.status === "done"),
-    [avatars],
-  );
-
-  const todayNewPendingCount = useMemo(
-    () => pendingAvatars.filter((avatar) => enteredCustomizationToday(avatar)).length,
-    [pendingAvatars],
-  );
-
   const tabAvatars = useMemo(
-    () => (taskTab === "pending" ? pendingAvatars : doneAvatars),
-    [doneAvatars, pendingAvatars, taskTab],
+    () =>
+      avatars.filter((avatar) =>
+        taskTab === "pending" ? avatar.status === "approved" || avatar.status === "processing" : avatar.status === "done",
+      ),
+    [avatars, taskTab],
   );
 
   const filteredAvatars = useMemo(
@@ -502,7 +643,8 @@ export default function Customization() {
           return true;
         }
 
-        return avatar.status === "done" || avatar.status === "processing" || avatar.status === "approved";
+        const progress = getTaskProgress(avatar.task, categoryFilter);
+        return (progress?.completed ?? 0) > 0;
       }),
     [categoryFilter, tabAvatars],
   );
@@ -566,6 +708,7 @@ export default function Customization() {
   const handleOpenUploadModal = (actionType: ActionType) => {
     setUploadActionType(actionType);
     setUploadImageUrl("");
+    setUploadFile(null);
     setUploadModalOpen(true);
   };
 
@@ -573,6 +716,8 @@ export default function Customization() {
     setUploadModalOpen(false);
     setUploadActionType(null);
     setUploadImageUrl("");
+    setUploadFile(null);
+    setUploadPreviewUrl("");
   };
 
   const handleSubmitAction = async () => {
@@ -580,15 +725,42 @@ export default function Customization() {
       return;
     }
 
-    const imageUrl = uploadImageUrl.trim();
-    if (!imageUrl) {
-      messageApi.warning("请输入图片 URL");
-      return;
-    }
-
     setSubmittingAction(true);
 
     try {
+      let imageUrl = uploadImageUrl.trim();
+
+      if (!imageUrl && uploadFile && isDemoMode) {
+        imageUrl = uploadPreviewUrl;
+      }
+
+      if (!imageUrl && uploadFile && !isDemoMode) {
+        if (!["image/jpeg", "image/png", "image/webp"].includes(uploadFile.type)) {
+          messageApi.warning("仅支持 JPG、PNG、WEBP 图片");
+          return;
+        }
+
+        const presign = await api.createUploadPresign(uploadFile.type as UploadContentType);
+        const uploadResponse = await fetch(presign.uploadUrl, {
+          method: "PUT",
+          headers: {
+            "Content-Type": uploadFile.type,
+          },
+          body: uploadFile,
+        });
+
+        if (!uploadResponse.ok) {
+          throw new Error("素材文件上传失败");
+        }
+
+        imageUrl = presign.publicUrl;
+      }
+
+      if (!imageUrl) {
+        messageApi.warning("请先选择图片文件或输入图片 URL");
+        return;
+      }
+
       if (isDemoMode) {
         const nextDemoDetails: CustomizationAvatarDetail[] = demoAvatarDetails.map((avatar) => {
           if (avatar.id !== selectedAvatarDetail.id) {
@@ -723,8 +895,10 @@ export default function Customization() {
 
   const renderCategoryStatus = (avatar: CustomizationAvatar) => {
     const avatarActions = selectedAvatarDetail?.id === avatar.id ? selectedAvatarDetail.actions : [];
+    const basicTaskProgress = getTaskProgress(avatar.task, "basic");
+    const funTaskProgress = getTaskProgress(avatar.task, "fun");
 
-    if (avatarActions.length === 0) {
+    if (avatarActions.length === 0 && !avatar.task) {
       const meta = getStatusMetaForAvatarStatus(avatar.status as CustomizationStatus);
 
       if (categoryFilter === "basic") {
@@ -744,17 +918,17 @@ export default function Customization() {
     }
 
     if (categoryFilter === "basic") {
-      const meta = getCategoryStatusTag(getCategoryProgress(avatarActions, "basic"));
+      const meta = getCategoryStatusTag(basicTaskProgress ?? getCategoryProgress(avatarActions, "basic"));
       return <Tag color={meta.color}>{`基础动作 · ${meta.label}`}</Tag>;
     }
 
     if (categoryFilter === "fun") {
-      const meta = getCategoryStatusTag(getCategoryProgress(avatarActions, "fun"));
+      const meta = getCategoryStatusTag(funTaskProgress ?? getCategoryProgress(avatarActions, "fun"));
       return <Tag color={meta.color}>{`个性化动作 · ${meta.label}`}</Tag>;
     }
 
-    const basicMeta = getCategoryStatusTag(getCategoryProgress(avatarActions, "basic"));
-    const funMeta = getCategoryStatusTag(getCategoryProgress(avatarActions, "fun"));
+    const basicMeta = getCategoryStatusTag(basicTaskProgress ?? getCategoryProgress(avatarActions, "basic"));
+    const funMeta = getCategoryStatusTag(funTaskProgress ?? getCategoryProgress(avatarActions, "fun"));
 
     return (
       <Space size={[6, 6]} wrap>
@@ -1084,16 +1258,36 @@ export default function Customization() {
         destroyOnClose
       >
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <Text type="secondary">上传图片文件</Text>
+            <input
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              onChange={(event) => {
+                const nextFile = event.target.files?.[0] ?? null;
+                setUploadFile(nextFile);
+                if (nextFile) {
+                  setUploadImageUrl("");
+                }
+              }}
+            />
+          </div>
+
           <Input
-            placeholder="请输入图片 URL"
+            placeholder="或输入图片 URL"
             value={uploadImageUrl}
-            onChange={(event) => setUploadImageUrl(event.target.value)}
+            onChange={(event) => {
+              setUploadImageUrl(event.target.value);
+              if (event.target.value.trim()) {
+                setUploadFile(null);
+              }
+            }}
           />
 
-          {uploadImageUrl.trim() ? (
+          {uploadPreviewUrl ? (
             <div style={{ display: "flex", justifyContent: "center" }}>
               <Image
-                src={uploadImageUrl.trim()}
+                src={uploadPreviewUrl}
                 alt={uploadActionType ? ACTION_LABELS[uploadActionType] ?? uploadActionType : "动作预览"}
                 width={240}
                 height={240}
@@ -1101,7 +1295,7 @@ export default function Customization() {
               />
             </div>
           ) : (
-            <Empty description="输入图片 URL 后可预览" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+            <Empty description="选择图片文件或输入图片 URL 后可预览" image={Empty.PRESENTED_IMAGE_SIMPLE} />
           )}
         </div>
       </Modal>

--- a/packages/admin/src/pages/Devices.tsx
+++ b/packages/admin/src/pages/Devices.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import type { TableProps } from "antd";
 import {
-  Divider,
   Button,
   Card,
   Col,
+  Divider,
   Input,
   Progress,
   Row,
@@ -15,13 +15,13 @@ import {
   Typography,
   message,
 } from "antd";
-import { ArrowLeftOutlined, CaretDownFilled, SearchOutlined } from "@ant-design/icons";
+import { ArrowLeftOutlined, SearchOutlined } from "@ant-design/icons";
 import dayjs from "dayjs";
+import type { AdminDeviceDetail, AdminDeviceListItem, DeviceType } from "shared";
 import { api } from "../api/client";
 
 const { Text, Title } = Typography;
 
-type DeviceType = "collar" | "desktop";
 type DeviceModelFilter = "all" | DeviceType;
 type DeviceStatusFilter = "all" | "online" | "offline" | "pairing";
 type DeviceBoundFilter = "all" | "bound" | "unbound";
@@ -30,187 +30,73 @@ type PetSpeciesValue = "cat" | "dog" | "other";
 type SpeciesFilter = "all" | PetSpeciesValue;
 type CreatedSortOrder = "desc" | "asc";
 
-interface BaseDevice {
-  id: string;
-  userId: string | null;
-  name: string | null;
-  macAddress: string | null;
-  status: string;
-  firmwareVersion: string | null;
-  lastOnlineAt: string | null;
-  createdAt: string;
-  updatedAt: string;
-  ownerNickname: string | null;
-}
-
-interface CollarDevice extends BaseDevice {
-  petId: string | null;
-  battery: number | null;
-  signal: number | null;
-  petName: string | null;
-  petSpecies: string | null;
-  hasUploadedImage: boolean;
-}
-
-interface DesktopDevice extends BaseDevice {
-  bindingPetNames: string[];
-  bindingPetSpeciesList: string[];
-  activeBindingCount: number;
-  hasUploadedImage: boolean;
-}
-
-type SelectedDevice =
-  | { type: "collar"; record: CollarDevice }
-  | { type: "desktop"; record: DesktopDevice };
-
-type DeviceListRecord = {
+type SelectedDeviceRef = {
   id: string;
   type: DeviceType;
-  modelLabel: string;
-  ownerNickname: string | null;
-  deviceName: string | null;
-  searchableText: string;
-  petImageStatus: DeviceImageFilter;
-  isBound: boolean;
-  bindingStatusLabel: string;
-  petBindingText: string;
-  petSpecies: PetSpeciesValue;
-  petSpeciesLabel: string;
-  status: string;
-  createdAt: string;
-  raw: CollarDevice | DesktopDevice;
 };
 
-type SelectedDeviceSummary = {
-  modelLabel: string;
-  petImageStatus: "uploaded" | "not_uploaded";
-  isBound: boolean;
-  petSpecies: PetSpeciesValue;
-  petBindingText: string;
-};
-
-const deviceModelLabels: Record<DeviceType, string> = {
+const DEVICE_MODEL_LABELS: Record<DeviceType, string> = {
   desktop: "桌面宠物1.0",
   collar: "宠物项圈1.0",
 };
 
-const statusColors: Record<string, string> = {
-  online: "green",
-  offline: "default",
-  pairing: "orange",
-};
-
-const statusLabels: Record<string, string> = {
+const STATUS_LABELS: Record<DeviceStatusFilter extends infer T ? Extract<T, string> : never, string> = {
+  all: "全部设备状态",
   online: "在线",
   offline: "离线",
   pairing: "连接中断",
 };
 
-const speciesLabels: Record<PetSpeciesValue, string> = {
+const STATUS_COLORS: Record<Exclude<DeviceStatusFilter, "all">, string> = {
+  online: "green",
+  offline: "default",
+  pairing: "orange",
+};
+
+const SPECIES_LABELS: Record<PetSpeciesValue, string> = {
   cat: "猫",
   dog: "狗",
   other: "其他",
 };
 
 const modelOptions = [
-  { value: "all", label: "全部型号" },
   { value: "desktop", label: "桌面宠物1.0" },
   { value: "collar", label: "宠物项圈1.0" },
 ] satisfies { value: DeviceModelFilter; label: string }[];
 
 const imageOptions = [
-  { value: "all", label: "全部图像状态" },
   { value: "uploaded", label: "已上传" },
   { value: "not_uploaded", label: "未上传" },
 ] satisfies { value: DeviceImageFilter; label: string }[];
 
 const boundOptions = [
-  { value: "all", label: "全部绑定状态" },
-  { value: "bound", label: "已绑定宠物" },
-  { value: "unbound", label: "未绑定宠物" },
+  { value: "bound", label: "已绑定" },
+  { value: "unbound", label: "未绑定" },
 ] satisfies { value: DeviceBoundFilter; label: string }[];
 
 const speciesOptions = [
-  { value: "all", label: "全部宠物类型" },
   { value: "cat", label: "猫" },
   { value: "dog", label: "狗" },
   { value: "other", label: "其他" },
 ] satisfies { value: SpeciesFilter; label: string }[];
 
 const statusOptions = [
-  { value: "all", label: "全部设备状态" },
   { value: "pairing", label: "连接中断" },
   { value: "online", label: "在线" },
   { value: "offline", label: "离线" },
 ] satisfies { value: DeviceStatusFilter; label: string }[];
 
 const sortOptions = [
-  { value: "desc", label: "注册时间：倒序" },
-  { value: "asc", label: "注册时间：顺序" },
+  { value: "desc", label: "倒序" },
+  { value: "asc", label: "顺序" },
 ] satisfies { value: CreatedSortOrder; label: string }[];
 
 function formatTime(value: string | null | undefined) {
   return value ? dayjs(value).format("YYYY-MM-DD HH:mm") : "-";
 }
 
-function renderStatus(value: string) {
-  return <Tag color={statusColors[value] ?? "default"}>{statusLabels[value] ?? value}</Tag>;
-}
-
-function renderImageStatus(value: DeviceImageFilter) {
-  if (value === "uploaded") {
-    return <Tag color="green">已上传</Tag>;
-  }
-
-  return <Tag color="default">未上传</Tag>;
-}
-
-function renderBindingStatus(isBound: boolean) {
-  return isBound ? <Tag color="green">已绑定</Tag> : <Tag color="default">未绑定</Tag>;
-}
-
-function renderSpeciesTag(value: PetSpeciesValue) {
-  const color = value === "cat" ? "purple" : value === "dog" ? "cyan" : "default";
-  return <Tag color={color}>{speciesLabels[value]}</Tag>;
-}
-
-function normalizeSpecies(value?: string | null): PetSpeciesValue {
-  if (value === "cat" || value === "dog") {
-    return value;
-  }
-
-  return "other";
-}
-
-function getDesktopSpecies(speciesList: string[] | undefined): PetSpeciesValue {
-  const uniqueSpecies = new Set((speciesList ?? []).map((item) => normalizeSpecies(item)));
-
-  if (uniqueSpecies.size === 1) {
-    return Array.from(uniqueSpecies)[0];
-  }
-
-  return "other";
-}
-
-function renderFilterTitle(label: string) {
-  return (
-    <Space size={4}>
-      <span>{label}</span>
-      <CaretDownFilled style={{ fontSize: 10, color: "#8c8c8c" }} />
-    </Space>
-  );
-}
-
-function pickSingleFilter<T extends string>(value: unknown, fallback: T): T {
-  if (Array.isArray(value) && typeof value[0] === "string") {
-    return value[0] as T;
-  }
-
-  if (typeof value === "string") {
-    return value as T;
-  }
-
-  return fallback;
+function formatShortDate(value: string | null | undefined) {
+  return value ? dayjs(value).format("YYYY-MM-DD") : "-";
 }
 
 function formatRelativeTime(value: string | null | undefined) {
@@ -259,82 +145,100 @@ function getSignalLabel(signal: number | null | undefined, status: string) {
   return "弱";
 }
 
-function buildDeviceRows(collars: CollarDevice[], desktops: DesktopDevice[]): DeviceListRecord[] {
-  const collarRows: DeviceListRecord[] = collars.map((record) => {
-    const petSpecies = normalizeSpecies(record.petSpecies);
-    const isBound = !!record.petId;
-    const petBindingText = record.petName ?? "-";
+function getSignalColor(signalLabel: string) {
+  if (signalLabel === "强") {
+    return "#16a34a";
+  }
 
-    return {
-      id: record.id,
-      type: "collar",
-      modelLabel: deviceModelLabels.collar,
-      ownerNickname: record.ownerNickname,
-      deviceName: record.name,
-      searchableText: [
-        record.id,
-        record.name,
-        record.ownerNickname,
-        record.petName,
-        deviceModelLabels.collar,
-        record.macAddress,
-      ]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase(),
-      petImageStatus: isBound && record.hasUploadedImage ? "uploaded" : "not_uploaded",
-      isBound,
-      bindingStatusLabel: isBound ? "已绑定宠物" : "未绑定宠物",
-      petBindingText,
-      petSpecies: isBound ? petSpecies : "other",
-      petSpeciesLabel: speciesLabels[isBound ? petSpecies : "other"],
-      status: record.status,
-      createdAt: record.createdAt,
-      raw: record,
-    };
-  });
+  if (signalLabel === "中") {
+    return "#d97706";
+  }
 
-  const desktopRows: DeviceListRecord[] = desktops.map((record) => {
-    const petSpecies = record.activeBindingCount > 0 ? getDesktopSpecies(record.bindingPetSpeciesList) : "other";
-    const isBound = record.activeBindingCount > 0;
-    const petBindingText = isBound ? record.bindingPetNames.join(" / ") : "-";
+  return "#9ca3af";
+}
 
-    return {
-      id: record.id,
-      type: "desktop",
-      modelLabel: deviceModelLabels.desktop,
-      ownerNickname: record.ownerNickname,
-      deviceName: record.name,
-      searchableText: [
-        record.id,
-        record.name,
-        record.ownerNickname,
-        record.bindingPetNames.join(" "),
-        deviceModelLabels.desktop,
-        record.macAddress,
-      ]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase(),
-      petImageStatus: isBound && record.hasUploadedImage ? "uploaded" : "not_uploaded",
-      isBound,
-      bindingStatusLabel: isBound ? "已绑定宠物" : "未绑定宠物",
-      petBindingText,
-      petSpecies,
-      petSpeciesLabel: speciesLabels[petSpecies],
-      status: record.status,
-      createdAt: record.createdAt,
-      raw: record,
-    };
-  });
+function normalizeSpecies(value?: string | null): PetSpeciesValue {
+  if (value === "cat" || value === "dog") {
+    return value;
+  }
 
-  return [...collarRows, ...desktopRows];
+  return "other";
+}
+
+function renderStatus(status: AdminDeviceListItem["status"]) {
+  return <Tag color={STATUS_COLORS[status]}>{STATUS_LABELS[status]}</Tag>;
+}
+
+function renderImageStatus(hasUploadedAvatar: boolean) {
+  return hasUploadedAvatar ? <Tag color="green">已上传</Tag> : <Tag color="default">未上传</Tag>;
+}
+
+function renderBindingStatus(isBound: boolean) {
+  return isBound ? <Tag color="green">已绑定</Tag> : <Tag color="default">未绑定</Tag>;
+}
+
+function pickSingleFilter<T extends string>(value: unknown, fallback: T): T {
+  if (Array.isArray(value) && typeof value[0] === "string") {
+    return value[0] as T;
+  }
+
+  if (typeof value === "string") {
+    return value as T;
+  }
+
+  return fallback;
+}
+
+function buildDeviceQuery(params: {
+  keyword: string;
+  modelFilter: DeviceModelFilter;
+  imageFilter: DeviceImageFilter;
+  boundFilter: DeviceBoundFilter;
+  speciesFilter: SpeciesFilter;
+  statusFilter: DeviceStatusFilter;
+  sortOrder: CreatedSortOrder;
+}) {
+  const query: Record<string, string> = {
+    page: "1",
+    pageSize: "100",
+    sort: "createdAt",
+    order: params.sortOrder,
+  };
+
+  if (params.keyword.trim()) {
+    query.keyword = params.keyword.trim();
+  }
+
+  if (params.modelFilter !== "all") {
+    query.type = params.modelFilter;
+  }
+
+  if (params.imageFilter === "uploaded") {
+    query.imageStatus = "uploaded";
+  } else if (params.imageFilter === "not_uploaded") {
+    query.imageStatus = "pending";
+  }
+
+  if (params.boundFilter !== "all") {
+    query.bindingStatus = params.boundFilter;
+  }
+
+  if (params.speciesFilter === "cat" || params.speciesFilter === "dog") {
+    query.species = params.speciesFilter;
+  }
+
+  if (params.statusFilter !== "all") {
+    query.status = params.statusFilter;
+  }
+
+  return query;
 }
 
 export default function DevicesPage() {
   const [loading, setLoading] = useState(true);
-  const [collars, setCollars] = useState<CollarDevice[]>([]);
-  const [desktops, setDesktops] = useState<DesktopDevice[]>([]);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [devices, setDevices] = useState<AdminDeviceListItem[]>([]);
+  const [total, setTotal] = useState(0);
   const [keyword, setKeyword] = useState("");
   const [modelFilter, setModelFilter] = useState<DeviceModelFilter>("all");
   const [imageFilter, setImageFilter] = useState<DeviceImageFilter>("all");
@@ -342,7 +246,9 @@ export default function DevicesPage() {
   const [speciesFilter, setSpeciesFilter] = useState<SpeciesFilter>("all");
   const [statusFilter, setStatusFilter] = useState<DeviceStatusFilter>("all");
   const [sortOrder, setSortOrder] = useState<CreatedSortOrder>("desc");
-  const [selectedDevice, setSelectedDevice] = useState<SelectedDevice | null>(null);
+  const [selectedDeviceRef, setSelectedDeviceRef] = useState<SelectedDeviceRef | null>(null);
+  const [selectedDeviceDetail, setSelectedDeviceDetail] = useState<AdminDeviceDetail | null>(null);
+  const deferredKeyword = useDeferredValue(keyword);
 
   useEffect(() => {
     let cancelled = false;
@@ -351,15 +257,24 @@ export default function DevicesPage() {
       setLoading(true);
 
       try {
-        const [collarResult, desktopResult] = await Promise.all([
-          api.getFilteredCollars({ sort: "createdAt", order: "desc" }),
-          api.getFilteredDesktops({ sort: "createdAt", order: "desc" }),
-        ]);
+        const response = await api.getDevices(
+          buildDeviceQuery({
+            keyword: deferredKeyword,
+            modelFilter,
+            imageFilter,
+            boundFilter,
+            speciesFilter,
+            statusFilter,
+            sortOrder,
+          }),
+        );
 
-        if (!cancelled) {
-          setCollars((collarResult.collars as CollarDevice[]) ?? []);
-          setDesktops((desktopResult.desktops as DesktopDevice[]) ?? []);
+        if (cancelled) {
+          return;
         }
+
+        setDevices(response.items ?? []);
+        setTotal(response.total ?? 0);
       } catch (error) {
         if (!cancelled) {
           message.error(error instanceof Error ? error.message : "设备数据加载失败");
@@ -371,63 +286,66 @@ export default function DevicesPage() {
       }
     }
 
-    void loadDevices();
+    const timer = window.setTimeout(() => {
+      void loadDevices();
+    }, 250);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [boundFilter, deferredKeyword, imageFilter, modelFilter, sortOrder, speciesFilter, statusFilter]);
+
+  useEffect(() => {
+    if (!selectedDeviceRef) {
+      setSelectedDeviceDetail(null);
+      return;
+    }
+
+    const currentRef = selectedDeviceRef;
+    let cancelled = false;
+
+    async function loadDetail() {
+      setDetailLoading(true);
+
+      try {
+        const detail = await api.getDeviceDetail(currentRef.type, currentRef.id);
+        if (!cancelled) {
+          setSelectedDeviceDetail(detail);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setSelectedDeviceDetail(null);
+          message.error(error instanceof Error ? error.message : "设备详情加载失败");
+        }
+      } finally {
+        if (!cancelled) {
+          setDetailLoading(false);
+        }
+      }
+    }
+
+    void loadDetail();
 
     return () => {
       cancelled = true;
     };
-  }, []);
-
-  const deviceRows = useMemo(() => buildDeviceRows(collars, desktops), [collars, desktops]);
+  }, [selectedDeviceRef]);
 
   const filteredDevices = useMemo(() => {
-    const normalizedKeyword = keyword.trim().toLowerCase();
+    if (speciesFilter !== "other") {
+      return devices;
+    }
 
-    return deviceRows
-      .filter((device) => {
-        if (normalizedKeyword && !device.searchableText.includes(normalizedKeyword)) {
-          return false;
-        }
-
-        if (modelFilter !== "all" && device.type !== modelFilter) {
-          return false;
-        }
-
-        if (imageFilter !== "all" && device.petImageStatus !== imageFilter) {
-          return false;
-        }
-
-        if (boundFilter === "bound" && !device.isBound) {
-          return false;
-        }
-
-        if (boundFilter === "unbound" && device.isBound) {
-          return false;
-        }
-
-        if (speciesFilter !== "all" && device.petSpecies !== speciesFilter) {
-          return false;
-        }
-
-        if (statusFilter !== "all" && device.status !== statusFilter) {
-          return false;
-        }
-
-        return true;
-      })
-      .sort((left, right) => {
-        const leftTime = dayjs(left.createdAt).valueOf();
-        const rightTime = dayjs(right.createdAt).valueOf();
-        return sortOrder === "asc" ? leftTime - rightTime : rightTime - leftTime;
-      });
-  }, [boundFilter, deviceRows, imageFilter, keyword, modelFilter, sortOrder, speciesFilter, statusFilter]);
+    return devices.filter((device) => normalizeSpecies(device.petSpecies) === "other");
+  }, [devices, speciesFilter]);
 
   const boundDeviceCount = useMemo(
-    () => filteredDevices.filter((device) => device.isBound).length,
+    () => filteredDevices.filter((device) => device.bindingCount > 0).length,
     [filteredDevices],
   );
 
-  const columns: TableProps<DeviceListRecord>["columns"] = [
+  const columns: TableProps<AdminDeviceListItem>["columns"] = [
     {
       title: "设备ID",
       dataIndex: "id",
@@ -436,195 +354,138 @@ export default function DevicesPage() {
       render: (value: string, record) => (
         <Space direction="vertical" size={2}>
           <Text strong>{value}</Text>
-          <Text type="secondary">{record.deviceName ?? "-"}</Text>
+          <Text type="secondary">{record.name || "-"}</Text>
         </Space>
       ),
     },
     {
       title: "Mac地址",
-      dataIndex: "raw",
+      dataIndex: "macAddress",
       key: "macAddress",
-      width: 180,
-      render: (_value, record) => (record.raw.macAddress ?? "-"),
+      width: 190,
+      render: (value: string | null) => value || "-",
     },
     {
       title: "设备型号",
-      dataIndex: "modelLabel",
-      key: "modelLabel",
+      dataIndex: "type",
+      key: "type",
       width: 150,
-      filters: modelOptions.filter((option) => option.value !== "all").map((option) => ({ text: option.label, value: option.value })),
+      filters: modelOptions.map((option) => ({ text: option.label, value: option.value })),
       filteredValue: modelFilter === "all" ? null : [modelFilter],
-      onFilter: (value, record) => record.type === value,
-      render: (value: string) => value,
+      filterMultiple: false,
+      render: (value: DeviceType) => DEVICE_MODEL_LABELS[value],
     },
     {
-      title: renderFilterTitle("宠物头像"),
-      dataIndex: "petImageStatus",
-      key: "petImageStatus",
+      title: "宠物头像",
+      dataIndex: "hasUploadedAvatar",
+      key: "hasUploadedAvatar",
       width: 120,
-      filters: imageOptions.filter((option) => option.value !== "all").map((option) => ({ text: option.label, value: option.value })),
+      filters: imageOptions.map((option) => ({ text: option.label, value: option.value })),
       filteredValue: imageFilter === "all" ? null : [imageFilter],
-      onFilter: (value, record) => record.petImageStatus === value,
-      render: (value: DeviceImageFilter) => renderImageStatus(value),
+      filterMultiple: false,
+      render: (value: boolean) => renderImageStatus(value),
     },
     {
-      title: renderFilterTitle("设备绑定"),
-      dataIndex: "isBound",
-      key: "isBound",
+      title: "设备绑定",
+      dataIndex: "bindingCount",
+      key: "bindingCount",
       width: 120,
-      filters: [
-        { text: "已绑定", value: "bound" },
-        { text: "未绑定", value: "unbound" },
-      ],
+      filters: boundOptions.map((option) => ({ text: option.label, value: option.value })),
       filteredValue: boundFilter === "all" ? null : [boundFilter],
-      onFilter: (value, record) => (value === "bound" ? record.isBound : !record.isBound),
-      render: (value: boolean) => renderBindingStatus(value),
+      filterMultiple: false,
+      render: (value: number) => renderBindingStatus(value > 0),
     },
     {
-      title: renderFilterTitle("宠物类型"),
-      dataIndex: "petSpecies",
-      key: "petSpecies",
+      title: "宠物类型",
+      dataIndex: "petName",
+      key: "petName",
       width: 180,
-      filters: speciesOptions.filter((option) => option.value !== "all").map((option) => ({ text: option.label, value: option.value })),
+      filters: speciesOptions.map((option) => ({ text: option.label, value: option.value })),
       filteredValue: speciesFilter === "all" ? null : [speciesFilter],
-      onFilter: (value, record) => record.petSpecies === value,
-      render: (value: PetSpeciesValue, record) => (
+      filterMultiple: false,
+      render: (_value, record) => (
         <Space direction="vertical" size={2}>
-          <Text>{record.petBindingText}</Text>
-          <Text type="secondary">{speciesLabels[value]}</Text>
+          <Text>{record.petName || "-"}</Text>
+          <Text type="secondary">{record.petName ? SPECIES_LABELS[normalizeSpecies(record.petSpecies)] : "-"}</Text>
         </Space>
       ),
     },
     {
-      title: renderFilterTitle("设备状态"),
+      title: "设备状态",
       dataIndex: "status",
       key: "status",
-      width: 120,
-      filters: statusOptions.filter((option) => option.value !== "all").map((option) => ({ text: option.label, value: option.value })),
+      width: 130,
+      filters: statusOptions.map((option) => ({ text: option.label, value: option.value })),
       filteredValue: statusFilter === "all" ? null : [statusFilter],
-      onFilter: (value, record) => record.status === value,
-      render: (value: string) => renderStatus(value),
+      filterMultiple: false,
+      render: (value: AdminDeviceListItem["status"]) => renderStatus(value),
     },
     {
       title: "用户信息",
-      dataIndex: "ownerNickname",
-      key: "ownerNickname",
+      dataIndex: "userNickname",
+      key: "userNickname",
       width: 140,
-      render: (value: string | null) => value ?? "-",
+      render: (value: string | null) => value || "-",
     },
     {
-      title: renderFilterTitle("注册时间"),
+      title: "注册时间",
       dataIndex: "createdAt",
       key: "createdAt",
       width: 180,
-      filters: [
-        { text: "倒序", value: "desc" },
-        { text: "顺序", value: "asc" },
-      ],
+      filters: sortOptions.map((option) => ({ text: option.label, value: option.value })),
       filteredValue: [sortOrder],
-      onFilter: () => true,
+      filterMultiple: false,
       render: (value: string) => formatTime(value),
     },
     {
       title: "管理设备",
       key: "actions",
-      width: 100,
+      width: 110,
       fixed: "right",
       render: (_value, record) => (
-        <Space size={4}>
-          <Button
-            type="link"
-            onClick={() =>
-              setSelectedDevice(
-                record.type === "collar"
-                  ? { type: "collar", record: record.raw as CollarDevice }
-                  : { type: "desktop", record: record.raw as DesktopDevice },
-              )
-            }
-          >
-            管理
-          </Button>
-        </Space>
+        <Button
+          type="link"
+          onClick={() =>
+            setSelectedDeviceRef({
+              id: record.id,
+              type: record.type,
+            })
+          }
+        >
+          管理
+        </Button>
       ),
     },
   ];
 
-  const selectedDeviceSummary = useMemo<SelectedDeviceSummary | null>(() => {
-    if (!selectedDevice) {
-      return null;
-    }
-
-    if (selectedDevice.type === "collar") {
-      const petSpecies = selectedDevice.record.petId ? normalizeSpecies(selectedDevice.record.petSpecies) : "other";
-      return {
-        modelLabel: deviceModelLabels.collar,
-        petImageStatus: selectedDevice.record.petId && selectedDevice.record.hasUploadedImage ? "uploaded" : "not_uploaded",
-        isBound: !!selectedDevice.record.petId,
-        petSpecies,
-        petBindingText: selectedDevice.record.petName ?? "-",
-      };
-    }
-
-    const petSpecies = selectedDevice.record.activeBindingCount > 0 ? getDesktopSpecies(selectedDevice.record.bindingPetSpeciesList) : "other";
-    return {
-      modelLabel: deviceModelLabels.desktop,
-      petImageStatus: selectedDevice.record.activeBindingCount > 0 && selectedDevice.record.hasUploadedImage ? "uploaded" : "not_uploaded",
-      isBound: selectedDevice.record.activeBindingCount > 0,
-      petSpecies,
-      petBindingText: selectedDevice.record.activeBindingCount > 0 ? selectedDevice.record.bindingPetNames.join(" / ") : "-",
-    };
-  }, [selectedDevice]);
-
-  const selectedDeviceTitle = useMemo(() => {
-    if (!selectedDevice || !selectedDeviceSummary) {
-      return "设备详情";
-    }
-
-    return `${selectedDevice.record.name ?? selectedDeviceSummary.modelLabel}设备详情`;
-  }, [selectedDevice, selectedDeviceSummary]);
-
-  const selectedDeviceDetail = useMemo(() => {
-    if (!selectedDevice || !selectedDeviceSummary) {
-      return null;
-    }
-
+  if (selectedDeviceRef) {
+    const detail = selectedDeviceDetail;
+    const device = detail?.device ?? null;
+    const pet = detail?.pet ?? null;
+    const owner = detail?.owner ?? null;
     const counterpart =
-      selectedDevice.type === "collar"
-        ? desktops.find((desktop) => desktop.userId && desktop.userId === selectedDevice.record.userId) ?? null
-        : collars.find((collar) => collar.userId && collar.userId === selectedDevice.record.userId) ?? null;
+      detail?.relatedDevices.find((item) => item.type !== detail.device.type) ??
+      detail?.relatedDevices[0] ??
+      null;
+    const batteryPercent = device?.battery ?? null;
+    const signalLabel = getSignalLabel(device?.signal, device?.status ?? "offline");
+    const signalColor = getSignalColor(signalLabel);
+    const completedActions = detail?.avatarProgress.approved ?? 0;
+    const totalActions = detail?.avatarProgress.total ?? 18;
+    const avatarUploaded = (detail?.avatarProgress.uploaded ?? 0) > 0;
+    const avatarApproved = (detail?.avatarProgress.approved ?? 0) > 0;
+    const avatarProgressPercent = totalActions > 0 ? Math.round((completedActions / totalActions) * 100) : 0;
+    const detailTitle = device?.name ? `${device.name}的设备详情` : "设备详情";
+    const currentDeviceLabel = device ? DEVICE_MODEL_LABELS[device.type] : "-";
+    const counterpartLabel = counterpart ? DEVICE_MODEL_LABELS[counterpart.type] : "-";
 
-    const isCollar = selectedDevice.type === "collar";
-    const batteryPercent = isCollar ? selectedDevice.record.battery ?? 85 : 85;
-    const signalLabel = isCollar
-      ? getSignalLabel(selectedDevice.record.signal, selectedDevice.record.status)
-      : getSignalLabel(null, selectedDevice.record.status);
-    const signalColor = signalLabel === "强" ? "#16a34a" : signalLabel === "中" ? "#d97706" : "#9ca3af";
-    const customizationCompleted = selectedDeviceSummary.petImageStatus === "uploaded" ? 3 : 0;
-    const customizationTotal = 18;
-    const bindingDurationDays = Math.max(1, dayjs().diff(dayjs(selectedDevice.record.createdAt), "day"));
-
-    return {
-      batteryPercent,
-      signalLabel,
-      signalColor,
-      lastSyncLabel: formatRelativeTime(selectedDevice.record.lastOnlineAt ?? selectedDevice.record.updatedAt),
-      activeAtLabel: formatTime(selectedDevice.record.createdAt),
-      counterpart,
-      customizationCompleted,
-      customizationTotal,
-      customizationPercent: Math.round((customizationCompleted / customizationTotal) * 100),
-      bindingDurationDays,
-    };
-  }, [collars, desktops, selectedDevice, selectedDeviceSummary]);
-
-  if (selectedDevice && selectedDeviceSummary && selectedDeviceDetail) {
     return (
       <Space direction="vertical" size={20} style={{ display: "flex" }}>
         <Button
           type="link"
           icon={<ArrowLeftOutlined />}
           style={{ padding: 0, width: "fit-content" }}
-          onClick={() => setSelectedDevice(null)}
+          onClick={() => setSelectedDeviceRef(null)}
         >
           返回列表
         </Button>
@@ -632,9 +493,18 @@ export default function DevicesPage() {
         <Card styles={{ body: { padding: 24 } }}>
           <Divider style={{ margin: "0 0 24px" }} />
 
-          <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "center", flexWrap: "wrap", marginBottom: 28 }}>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              gap: 16,
+              flexWrap: "wrap",
+              marginBottom: 28,
+            }}
+          >
             <Title level={3} style={{ margin: 0 }}>
-              {selectedDeviceTitle}
+              {detailTitle}
             </Title>
 
             <Space size={16}>
@@ -651,276 +521,321 @@ export default function DevicesPage() {
               >
                 管理员编辑
               </Button>
-              <Button
-                danger
-                disabled
-                style={{
-                  minWidth: 120,
-                  height: 40,
-                  borderRadius: 12,
-                }}
-              >
+              <Button danger disabled style={{ minWidth: 120, height: 40, borderRadius: 12 }}>
                 永久删除
               </Button>
             </Space>
           </div>
 
-          <Row gutter={[32, 20]} style={{ marginBottom: 28 }}>
-            <Col xs={24} md={12} xl={6}>
-              <Space direction="vertical" size={10}>
-                <div><Text type="secondary">设备名称</Text> <Text strong>{selectedDevice.record.name ?? "-"}</Text></div>
-                <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-                  <Text type="secondary">电池状态</Text>
-                  <Text strong>{`${selectedDeviceDetail.batteryPercent}%`}</Text>
-                  <Progress
-                    percent={selectedDeviceDetail.batteryPercent}
-                    showInfo={false}
-                    strokeColor="#22c55e"
-                    trailColor="#e5e7eb"
-                    style={{ width: 90, marginInlineStart: 4 }}
-                  />
-                </div>
-              </Space>
-            </Col>
-            <Col xs={24} md={12} xl={6}>
-              <Space direction="vertical" size={10}>
-                <div><Text type="secondary">设备型号</Text> <Text strong>{selectedDeviceSummary.modelLabel}</Text></div>
-                <div><Text type="secondary">信号强度</Text> <Text strong style={{ color: selectedDeviceDetail.signalColor }}>{selectedDeviceDetail.signalLabel}</Text></div>
-              </Space>
-            </Col>
-            <Col xs={24} md={12} xl={6}>
-              <Space direction="vertical" size={10}>
-                <div><Text type="secondary">MAC地址</Text> <Text strong>{selectedDevice.record.macAddress ?? "-"}</Text></div>
-                <div><Text type="secondary">最后同步</Text> <Text strong>{selectedDeviceDetail.lastSyncLabel}</Text></div>
-              </Space>
-            </Col>
-            <Col xs={24} md={12} xl={6}>
-              <Space direction="vertical" size={10}>
-                <div><Text type="secondary">固件版本</Text> <Text strong>{selectedDevice.record.firmwareVersion ?? "v2.4.1"}</Text></div>
-                <div><Text type="secondary">激活时间</Text> <Text strong>{selectedDeviceDetail.activeAtLabel}</Text></div>
-              </Space>
-            </Col>
-          </Row>
-
-          <Card title={<Text strong style={{ fontSize: 16 }}>设备宠物</Text>} styles={{ body: { padding: 16 } }}>
-            <Row gutter={[16, 16]}>
-              <Col xs={24} xl={12}>
-                <Card
-                  bordered={false}
-                  style={{ background: "#f8fafc", borderRadius: 16, minHeight: 250 }}
-                  styles={{ body: { padding: 18 } }}
-                >
-                  <Space direction="vertical" size={12} style={{ width: "100%" }}>
-                    <div>
-                      <Text strong>设备宠物信息</Text>
-                      <div style={{ marginTop: 4 }}>{renderBindingStatus(selectedDeviceSummary.isBound)}</div>
-                    </div>
-
-                    <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
-                      <div
-                        style={{
-                          width: 84,
-                          height: 84,
-                          borderRadius: "50%",
-                          background: "#dbe4f0",
-                          flexShrink: 0,
-                        }}
-                      />
-                      <div style={{ minWidth: 0 }}>
-                        <Title level={4} style={{ margin: 0 }}>
-                          {selectedDeviceSummary.petBindingText}
-                        </Title>
-                        <Text type="secondary">
-                          {`${speciesLabels[selectedDeviceSummary.petSpecies]} | ${selectedDevice.record.id.slice(0, 4).toUpperCase()}`}
+          <Spin spinning={detailLoading}>
+            {detail && device ? (
+              <>
+                <Row gutter={[32, 20]} style={{ marginBottom: 28 }}>
+                  <Col xs={24} md={12} xl={6}>
+                    <Space direction="vertical" size={10}>
+                      <div>
+                        <Text type="secondary">设备名称</Text> <Text strong>{device.name || "-"}</Text>
+                      </div>
+                      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                        <Text type="secondary">电池状态</Text>
+                        <Text strong>{batteryPercent == null ? "-" : `${batteryPercent}%`}</Text>
+                        <Progress
+                          percent={batteryPercent ?? 0}
+                          showInfo={false}
+                          strokeColor={batteryPercent == null ? "#cbd5e1" : "#22c55e"}
+                          trailColor="#e5e7eb"
+                          style={{ width: 90, marginInlineStart: 4 }}
+                        />
+                      </div>
+                    </Space>
+                  </Col>
+                  <Col xs={24} md={12} xl={6}>
+                    <Space direction="vertical" size={10}>
+                      <div>
+                        <Text type="secondary">设备型号</Text> <Text strong>{currentDeviceLabel}</Text>
+                      </div>
+                      <div>
+                        <Text type="secondary">信号强度</Text>{" "}
+                        <Text strong style={{ color: signalColor }}>
+                          {signalLabel}
                         </Text>
                       </div>
-                    </div>
-
-                    <Row gutter={[12, 12]}>
-                      <Col span={8}>
-                        <Text type="secondary">主人</Text>
-                        <div><Text strong>{selectedDevice.record.ownerNickname ?? "-"}</Text></div>
-                      </Col>
-                      <Col span={8}>
-                        <Text type="secondary">陪伴时长</Text>
-                        <div><Text strong style={{ color: "#3b82f6" }}>{`${selectedDeviceDetail.bindingDurationDays}天`}</Text></div>
-                      </Col>
-                      <Col span={8}>
-                        <Text type="secondary">宠物编号</Text>
-                        <div><Text strong>{selectedDeviceSummary.isBound ? `PET${selectedDevice.record.id.slice(-3).toUpperCase()}` : "-"}</Text></div>
-                      </Col>
-                    </Row>
-                  </Space>
-                </Card>
-              </Col>
-
-              <Col xs={24} xl={12}>
-                <Card
-                  bordered={false}
-                  style={{ background: "#effcf5", borderRadius: 16, minHeight: 250 }}
-                  styles={{ body: { padding: 18 } }}
-                >
-                  <Space direction="vertical" size={12} style={{ width: "100%" }}>
-                    <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
-                      <div>
-                        <Text strong style={{ color: "#166534" }}>宠物图像定制</Text>
-                        <div style={{ marginTop: 4 }}><Text type="secondary">定制中</Text></div>
-                      </div>
-                      <Text strong style={{ color: "#166534", fontSize: 28 }}>
-                        {`${selectedDeviceDetail.customizationCompleted}/${selectedDeviceDetail.customizationTotal} 完成`}
-                      </Text>
-                    </div>
-
-                    <Space direction="vertical" size={8}>
-                      <Text style={{ color: "#166534" }}>{selectedDeviceSummary.petImageStatus === "uploaded" ? "✓ 图像已上传" : "× 图像未上传"}</Text>
-                      <Text style={{ color: "#166534" }}>{selectedDeviceSummary.petImageStatus === "uploaded" ? "✓ 图像已审核" : "× 等待图像审核"}</Text>
-                      <Text type="secondary">{`× 动态生成中 ${selectedDeviceDetail.customizationCompleted}/${selectedDeviceDetail.customizationTotal}`}</Text>
                     </Space>
+                  </Col>
+                  <Col xs={24} md={12} xl={6}>
+                    <Space direction="vertical" size={10}>
+                      <div>
+                        <Text type="secondary">MAC地址</Text> <Text strong>{device.macAddress || "-"}</Text>
+                      </div>
+                      <div>
+                        <Text type="secondary">最后同步</Text> <Text strong>{formatRelativeTime(detail.lastSyncedAt)}</Text>
+                      </div>
+                    </Space>
+                  </Col>
+                  <Col xs={24} md={12} xl={6}>
+                    <Space direction="vertical" size={10}>
+                      <div>
+                        <Text type="secondary">固件版本</Text> <Text strong>-</Text>
+                      </div>
+                      <div>
+                        <Text type="secondary">激活时间</Text> <Text strong>{formatTime(detail.activatedAt)}</Text>
+                      </div>
+                    </Space>
+                  </Col>
+                </Row>
 
-                    <Progress
-                      percent={selectedDeviceDetail.customizationPercent}
-                      showInfo={false}
-                      strokeColor="#22c55e"
-                      trailColor="#dbe4f0"
-                    />
+                <Card title={<Text strong style={{ fontSize: 16 }}>设备宠物</Text>} styles={{ body: { padding: 16 } }}>
+                  <Row gutter={[16, 16]}>
+                    <Col xs={24} xl={12}>
+                      <Card bordered={false} style={{ background: "#f8fafc", borderRadius: 16, minHeight: 250 }} styles={{ body: { padding: 18 } }}>
+                        <Space direction="vertical" size={12} style={{ width: "100%" }}>
+                          <div>
+                            <Text strong>设备宠物信息</Text>
+                            <div style={{ marginTop: 4 }}>{renderBindingStatus(!!pet)}</div>
+                          </div>
 
-                    <div style={{ display: "flex", justifyContent: "flex-end" }}>
-                      <Text type="secondary">{`最后更新 ${formatTime(selectedDevice.record.updatedAt)}`}</Text>
-                    </div>
-                  </Space>
-                </Card>
-              </Col>
+                          <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+                            {pet?.avatarUrl ? (
+                              <img
+                                src={pet.avatarUrl}
+                                alt={pet.name}
+                                style={{
+                                  width: 84,
+                                  height: 84,
+                                  borderRadius: "50%",
+                                  objectFit: "cover",
+                                  flexShrink: 0,
+                                }}
+                              />
+                            ) : (
+                              <div
+                                style={{
+                                  width: 84,
+                                  height: 84,
+                                  borderRadius: "50%",
+                                  background: "#dbe4f0",
+                                  flexShrink: 0,
+                                }}
+                              />
+                            )}
 
-              <Col xs={24} xl={12}>
-                <Card
-                  bordered={false}
-                  style={{ background: "#eef5ff", borderRadius: 16, minHeight: 220 }}
-                  styles={{ body: { padding: 18 } }}
-                >
-                  <Space direction="vertical" size={16} style={{ width: "100%" }}>
-                    <div>
-                      <Text strong style={{ color: "#1d4ed8" }}>
-                        {selectedDevice.type === "desktop" ? "桌面端与项圈绑定" : "项圈与桌面端绑定"}
-                      </Text>
-                      <div style={{ marginTop: 4 }}>{renderBindingStatus(!!selectedDeviceDetail.counterpart)}</div>
-                    </div>
+                            <div style={{ minWidth: 0 }}>
+                              <Title level={4} style={{ margin: 0 }}>
+                                {pet?.name ?? "未绑定宠物"}
+                              </Title>
+                              <Text type="secondary">
+                                {pet ? `${pet.speciesLabel}` : "暂未绑定"}
+                              </Text>
+                            </div>
+                          </div>
 
-                    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
-                      <Card bordered={false} style={{ background: "#dbeafe", width: "100%" }} styles={{ body: { padding: 16, textAlign: "center" } }}>
-                        <Text type="secondary">{selectedDevice.type === "desktop" ? "桌面端" : "项圈"}</Text>
-                        <Title level={4} style={{ margin: "8px 0 0" }}>{selectedDevice.record.name ?? selectedDeviceSummary.modelLabel}</Title>
+                          <Row gutter={[12, 12]}>
+                            <Col span={8}>
+                              <Text type="secondary">主人</Text>
+                              <div>
+                                <Text strong>{owner?.nickname ?? "-"}</Text>
+                              </div>
+                            </Col>
+                            <Col span={8}>
+                              <Text type="secondary">陪伴时长</Text>
+                              <div>
+                                <Text strong style={{ color: "#3b82f6" }}>
+                                  {pet ? `${pet.companionDays}天` : "-"}
+                                </Text>
+                              </div>
+                            </Col>
+                            <Col span={8}>
+                              <Text type="secondary">宠物编号</Text>
+                              <div>
+                                <Text strong>{pet?.id ?? "-"}</Text>
+                              </div>
+                            </Col>
+                          </Row>
+                        </Space>
                       </Card>
-                      <Text style={{ fontSize: 28, color: "#0f172a" }}>⟷</Text>
-                      <Card bordered={false} style={{ background: "#dbeafe", width: "100%" }} styles={{ body: { padding: 16, textAlign: "center" } }}>
-                        <Text type="secondary">{selectedDevice.type === "desktop" ? "项圈" : "桌面端"}</Text>
-                        <Title level={4} style={{ margin: "8px 0 0" }}>
-                          {selectedDeviceDetail.counterpart?.name ?? "暂无绑定设备"}
-                        </Title>
+                    </Col>
+
+                    <Col xs={24} xl={12}>
+                      <Card bordered={false} style={{ background: "#effcf5", borderRadius: 16, minHeight: 250 }} styles={{ body: { padding: 18 } }}>
+                        <Space direction="vertical" size={12} style={{ width: "100%" }}>
+                          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+                            <div>
+                              <Text strong style={{ color: "#166534" }}>宠物图像定制</Text>
+                              <div style={{ marginTop: 4 }}>
+                                <Text type="secondary">
+                                  {completedActions >= totalActions && totalActions > 0 ? "已完成" : avatarUploaded ? "定制中" : "待开始"}
+                                </Text>
+                              </div>
+                            </div>
+                            <Text strong style={{ color: "#166534", fontSize: 28 }}>
+                              {`${completedActions}/${totalActions} 完成`}
+                            </Text>
+                          </div>
+
+                          <Space direction="vertical" size={8}>
+                            <Text style={{ color: avatarUploaded ? "#166534" : "#8c8c8c" }}>
+                              {avatarUploaded ? "✓ 图像已上传" : "× 图像未上传"}
+                            </Text>
+                            <Text style={{ color: avatarApproved ? "#166534" : "#8c8c8c" }}>
+                              {avatarApproved ? "✓ 图像已审核" : detail.avatarProgress.pending > 0 ? `审核中 ${detail.avatarProgress.pending}` : "× 等待图像审核"}
+                            </Text>
+                            <Text type="secondary">{`动态生成中 ${completedActions}/${totalActions}`}</Text>
+                          </Space>
+
+                          <Progress percent={avatarProgressPercent} showInfo={false} strokeColor="#22c55e" trailColor="#dbe4f0" />
+
+                          <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                            <Text type="secondary">{`最后更新 ${formatTime(detail.lastSyncedAt ?? device.lastOnlineAt)}`}</Text>
+                          </div>
+                        </Space>
                       </Card>
-                    </div>
+                    </Col>
 
-                    <div style={{ textAlign: "center" }}>
-                      <Text type="secondary">{selectedDeviceDetail.counterpart ? `绑定${selectedDeviceDetail.bindingDurationDays}天` : "待建立绑定关系"}</Text>
-                    </div>
-                  </Space>
+                    <Col xs={24} xl={12}>
+                      <Card bordered={false} style={{ background: "#eef5ff", borderRadius: 16, minHeight: 220 }} styles={{ body: { padding: 18 } }}>
+                        <Space direction="vertical" size={16} style={{ width: "100%" }}>
+                          <div>
+                            <Text strong style={{ color: "#1d4ed8" }}>
+                              {device.type === "desktop" ? "桌面端与项圈绑定" : "项圈与桌面端绑定"}
+                            </Text>
+                            <div style={{ marginTop: 4 }}>{renderBindingStatus(!!counterpart)}</div>
+                          </div>
+
+                          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+                            <Card bordered={false} style={{ background: "#dbeafe", width: "100%" }} styles={{ body: { padding: 16, textAlign: "center" } }}>
+                              <Text type="secondary">{device.type === "desktop" ? "桌面端" : "项圈"}</Text>
+                              <Title level={4} style={{ margin: "8px 0 0" }}>
+                                {device.name || currentDeviceLabel}
+                              </Title>
+                            </Card>
+                            <Text style={{ fontSize: 28, color: "#0f172a" }}>⟷</Text>
+                            <Card bordered={false} style={{ background: "#dbeafe", width: "100%" }} styles={{ body: { padding: 16, textAlign: "center" } }}>
+                              <Text type="secondary">{counterpart ? (counterpart.type === "desktop" ? "桌面端" : "项圈") : counterpartLabel}</Text>
+                              <Title level={4} style={{ margin: "8px 0 0" }}>
+                                {counterpart?.name ?? "暂无绑定设备"}
+                              </Title>
+                            </Card>
+                          </div>
+
+                          <div style={{ textAlign: "center" }}>
+                            <Text type="secondary">{counterpart ? "已建立关联设备" : "待建立绑定关系"}</Text>
+                          </div>
+                        </Space>
+                      </Card>
+                    </Col>
+
+                    <Col xs={24} xl={12}>
+                      <Card bordered={false} style={{ background: "#fff7ed", borderRadius: 16, minHeight: 220 }} styles={{ body: { padding: 18 } }}>
+                        <Space direction="vertical" size={16} style={{ width: "100%" }}>
+                          <div>
+                            <Text strong style={{ color: "#c2410c" }}>设备状态信息</Text>
+                            <div style={{ marginTop: 4 }}>{renderStatus(device.status)}</div>
+                          </div>
+
+                          <Row gutter={[16, 16]}>
+                            <Col span={12}>
+                              <Text type="secondary">连接状态</Text>
+                              <div>
+                                <Text strong style={{ color: device.status === "online" ? "#16a34a" : "#c2410c" }}>
+                                  {device.status === "online" ? "已连接" : STATUS_LABELS[device.status]}
+                                </Text>
+                              </div>
+                            </Col>
+                            <Col span={12}>
+                              <Text type="secondary">设备型号</Text>
+                              <div>
+                                <Text strong>{currentDeviceLabel}</Text>
+                              </div>
+                            </Col>
+                            <Col span={12}>
+                              <Text type="secondary">最近活跃</Text>
+                              <div>
+                                <Text strong>{formatRelativeTime(device.lastOnlineAt)}</Text>
+                              </div>
+                            </Col>
+                            <Col span={12}>
+                              <Text type="secondary">激活时间</Text>
+                              <div>
+                                <Text strong>{formatShortDate(detail.activatedAt)}</Text>
+                              </div>
+                            </Col>
+                            <Col span={12}>
+                              <Text type="secondary">电池</Text>
+                              <div>
+                                <Text strong>{batteryPercent == null ? "-" : `${batteryPercent}%`}</Text>
+                              </div>
+                            </Col>
+                            <Col span={12}>
+                              <Text type="secondary">信号</Text>
+                              <div>
+                                <Text strong style={{ color: signalColor }}>
+                                  {signalLabel}
+                                </Text>
+                              </div>
+                            </Col>
+                          </Row>
+                        </Space>
+                      </Card>
+                    </Col>
+                  </Row>
                 </Card>
-              </Col>
-
-              <Col xs={24} xl={12}>
-                <Card
-                  bordered={false}
-                  style={{ background: "#fff7ed", borderRadius: 16, minHeight: 220 }}
-                  styles={{ body: { padding: 18 } }}
-                >
-                  <Space direction="vertical" size={16} style={{ width: "100%" }}>
-                    <div>
-                      <Text strong style={{ color: "#c2410c" }}>项圈状态信息</Text>
-                      <div style={{ marginTop: 4 }}>{renderStatus(selectedDevice.record.status)}</div>
-                    </div>
-
-                    <Row gutter={[16, 16]}>
-                      <Col span={12}>
-                        <Text type="secondary">连接状态</Text>
-                        <div><Text strong style={{ color: "#16a34a" }}>{selectedDevice.record.status === "online" ? "已连接" : statusLabels[selectedDevice.record.status] ?? "-"}</Text></div>
-                      </Col>
-                      <Col span={12}>
-                        <Text type="secondary">设备型号</Text>
-                        <div><Text strong>{selectedDeviceSummary.modelLabel}</Text></div>
-                      </Col>
-                      <Col span={12}>
-                        <Text type="secondary">最近活跃</Text>
-                        <div><Text strong>{selectedDeviceDetail.lastSyncLabel}</Text></div>
-                      </Col>
-                      <Col span={12}>
-                        <Text type="secondary">激活时间</Text>
-                        <div><Text strong>{dayjs(selectedDevice.record.createdAt).format("YYYY-MM-DD")}</Text></div>
-                      </Col>
-                      <Col span={12}>
-                        <Text type="secondary">电池</Text>
-                        <div><Text strong>{`${selectedDeviceDetail.batteryPercent}%`}</Text></div>
-                      </Col>
-                      <Col span={12}>
-                        <Text type="secondary">信号</Text>
-                        <div><Text strong style={{ color: selectedDeviceDetail.signalColor }}>{selectedDeviceDetail.signalLabel}</Text></div>
-                      </Col>
-                    </Row>
-                  </Space>
-                </Card>
-              </Col>
-            </Row>
-          </Card>
+              </>
+            ) : (
+              <Card>
+                <Text type="secondary">设备详情加载失败或数据为空。</Text>
+              </Card>
+            )}
+          </Spin>
         </Card>
       </Space>
     );
   }
 
   return (
-    <>
-      <Space direction="vertical" size={16} style={{ display: "flex" }}>
-        <div>
-          <Title level={2} style={{ margin: 0 }}>
-            设备管理
-          </Title>
-        </div>
+    <Space direction="vertical" size={16} style={{ display: "flex" }}>
+      <div>
+        <Title level={2} style={{ margin: 0 }}>
+          设备管理
+        </Title>
+      </div>
 
-        <Card>
-          <Input
-            allowClear
-            value={keyword}
-            prefix={<SearchOutlined />}
-            placeholder="搜索ID设备、型号、用户..."
-            onChange={(event) => setKeyword(event.target.value)}
+      <Card>
+        <Input
+          allowClear
+          value={keyword}
+          prefix={<SearchOutlined />}
+          placeholder="搜索ID设备、型号、用户..."
+          onChange={(event) => setKeyword(event.target.value)}
+        />
+      </Card>
+
+      <Card
+        title={
+          <Space split={<Text type="secondary">|</Text>}>
+            <Text strong>设备列表</Text>
+            <Text type="secondary">共 {speciesFilter === "other" ? filteredDevices.length : total} 台设备</Text>
+            <Text type="secondary">{boundDeviceCount} 台设备已绑定</Text>
+          </Space>
+        }
+      >
+        <Spin spinning={loading}>
+          <Table<AdminDeviceListItem>
+            dataSource={filteredDevices}
+            columns={columns}
+            rowKey={(record) => `${record.type}-${record.id}`}
+            scroll={{ x: 1440 }}
+            pagination={{ pageSize: 10, showSizeChanger: false }}
+            onChange={(_pagination, filters) => {
+              setModelFilter(pickSingleFilter<DeviceModelFilter>(filters.type, "all"));
+              setImageFilter(pickSingleFilter<DeviceImageFilter>(filters.hasUploadedAvatar, "all"));
+              setBoundFilter(pickSingleFilter<DeviceBoundFilter>(filters.bindingCount, "all"));
+              setSpeciesFilter(pickSingleFilter<SpeciesFilter>(filters.petName, "all"));
+              setStatusFilter(pickSingleFilter<DeviceStatusFilter>(filters.status, "all"));
+              setSortOrder(pickSingleFilter<CreatedSortOrder>(filters.createdAt, "desc"));
+            }}
           />
-        </Card>
-
-        <Card
-          title={
-            <Space split={<Text type="secondary">|</Text>}>
-              <Text strong>设备列表</Text>
-              <Text type="secondary">共 {filteredDevices.length} 台设备</Text>
-              <Text type="secondary">{boundDeviceCount} 台设备已绑定</Text>
-            </Space>
-          }
-        >
-          <Spin spinning={loading}>
-            <Table<DeviceListRecord>
-              dataSource={filteredDevices}
-              columns={columns}
-              rowKey={(record) => `${record.type}-${record.id}`}
-              scroll={{ x: 1380 }}
-              pagination={{ pageSize: 10, showSizeChanger: false }}
-              onChange={(_pagination, filters) => {
-                setModelFilter(pickSingleFilter<DeviceModelFilter>(filters.modelLabel, "all"));
-                setImageFilter(pickSingleFilter<DeviceImageFilter>(filters.petImageStatus, "all"));
-                setBoundFilter(pickSingleFilter<DeviceBoundFilter>(filters.isBound, "all"));
-                setSpeciesFilter(pickSingleFilter<SpeciesFilter>(filters.petSpecies, "all"));
-                setStatusFilter(pickSingleFilter<DeviceStatusFilter>(filters.status, "all"));
-                setSortOrder(pickSingleFilter<CreatedSortOrder>(filters.createdAt, "desc"));
-              }}
-            />
-          </Spin>
-        </Card>
-      </Space>
-    </>
+        </Spin>
+      </Card>
+    </Space>
   );
 }

--- a/packages/admin/src/pages/ImageReview.tsx
+++ b/packages/admin/src/pages/ImageReview.tsx
@@ -17,7 +17,7 @@ import {
   message,
 } from "antd";
 import dayjs, { type Dayjs } from "dayjs";
-import type { AvatarStatus, PetAvatar, Species, User } from "shared";
+import type { AvatarReviewStats, AvatarStatus, PetAvatar, Species, User } from "shared";
 import type { Pet, PetAvatarAction } from "shared";
 import { api } from "../api/client";
 
@@ -290,6 +290,12 @@ export default function ImageReview() {
   const [avatars, setAvatars] = useState<ReviewAvatar[]>(() => initialDemoDetails.map(toReviewAvatarSummary));
   const [demoAvatarDetails, setDemoAvatarDetails] = useState<ReviewAvatarDetail[]>(() => initialDemoDetails);
   const [isDemoMode, setIsDemoMode] = useState(true);
+  const [reviewStats, setReviewStats] = useState<AvatarReviewStats | null>({
+    pendingReview: initialDemoDetails.filter((avatar) => avatar.status === "pending").length,
+    approvedTotal: initialDemoDetails.filter((avatar) => ["approved", "processing", "done"].includes(avatar.status)).length,
+    syncedToDevices: initialDemoDetails.filter((avatar) => avatar.status === "done").length,
+    todayNewUploads: initialDemoDetails.filter((avatar) => isSameDay(avatar.createdAt, dayjs())).length,
+  });
   const [loading, setLoading] = useState(false);
   const [detailLoading, setDetailLoading] = useState(false);
   const [activeTab, setActiveTab] = useState<ReviewTabKey>("all");
@@ -303,34 +309,52 @@ export default function ImageReview() {
     setLoading(true);
 
     try {
-      const response = await api.getAvatars();
+      const [response, statsResponse] = await Promise.all([
+        api.getAvatars(),
+        api.getAvatarReviewStats().catch(() => null),
+      ]);
       const nextAvatars = (response.avatars as ReviewAvatar[]) ?? [];
       if (nextAvatars.length === 0) {
         if (options?.skipDemoFallback) {
           setDemoAvatarDetails([]);
           setAvatars([]);
           setIsDemoMode(false);
+          setReviewStats(statsResponse);
           return [];
         }
 
         const nextDemoDetails = applyDemoDataState(setDemoAvatarDetails, setAvatars, setIsDemoMode);
+        setReviewStats({
+          pendingReview: nextDemoDetails.filter((avatar) => avatar.status === "pending").length,
+          approvedTotal: nextDemoDetails.filter((avatar) => ["approved", "processing", "done"].includes(avatar.status)).length,
+          syncedToDevices: nextDemoDetails.filter((avatar) => avatar.status === "done").length,
+          todayNewUploads: nextDemoDetails.filter((avatar) => isSameDay(avatar.createdAt, dayjs())).length,
+        });
         return nextDemoDetails.map(toReviewAvatarSummary);
       }
 
       setIsDemoMode(false);
       setDemoAvatarDetails([]);
       setAvatars(nextAvatars);
+      setReviewStats(statsResponse);
       return nextAvatars;
     } catch (error) {
       if (options?.skipDemoFallback) {
         setDemoAvatarDetails([]);
         setAvatars([]);
         setIsDemoMode(false);
+        setReviewStats(null);
         messageApi.error(error instanceof Error ? error.message : "图像审核数据加载失败");
         return [];
       }
 
       const nextDemoDetails = applyDemoDataState(setDemoAvatarDetails, setAvatars, setIsDemoMode);
+      setReviewStats({
+        pendingReview: nextDemoDetails.filter((avatar) => avatar.status === "pending").length,
+        approvedTotal: nextDemoDetails.filter((avatar) => ["approved", "processing", "done"].includes(avatar.status)).length,
+        syncedToDevices: nextDemoDetails.filter((avatar) => avatar.status === "done").length,
+        todayNewUploads: nextDemoDetails.filter((avatar) => isSameDay(avatar.createdAt, dayjs())).length,
+      });
       messageApi.warning("未获取到真实数据，当前展示演示数据");
       return nextDemoDetails.map(toReviewAvatarSummary);
     } finally {
@@ -432,8 +456,8 @@ export default function ImageReview() {
   );
 
   const syncedDeviceCount = useMemo(
-    () => avatars.filter((avatar) => avatar.status === "done").length,
-    [avatars],
+    () => reviewStats?.syncedToDevices ?? avatars.filter((avatar) => avatar.status === "done").length,
+    [avatars, reviewStats],
   );
 
   const todaySyncedCount = useMemo(

--- a/packages/admin/src/pages/Users.tsx
+++ b/packages/admin/src/pages/Users.tsx
@@ -16,6 +16,7 @@ import {
   message,
 } from "antd";
 import { ArrowLeftOutlined, CheckSquareFilled, PlusOutlined } from "@ant-design/icons";
+import { DEFAULT_FREE_BENEFITS, type Membership, type MembershipBenefit } from "shared";
 import { api } from "../api/client";
 import dayjs from "dayjs";
 
@@ -80,13 +81,6 @@ interface UserDetail {
   };
 }
 
-const membershipPerks = [
-  { label: "尊享 60fps 帧率", enabled: true },
-  { label: "优先生成权", enabled: true },
-  { label: "无限定制额度", enabled: false },
-  { label: "专属客服支持", enabled: false },
-] as const;
-
 function formatTime(value: string | null | undefined) {
   return value ? dayjs(value).format("YYYY-MM-DD HH:mm") : "-";
 }
@@ -108,28 +102,32 @@ function buildDisplayUserCode(user: Pick<UserRecord, "id" | "nickname">) {
   return `${user.id.slice(0, 8)}(${user.nickname})`;
 }
 
-function getMembershipLevel(quota: number) {
-  if (quota >= 8) {
-    return "黄金会员";
-  }
-
-  if (quota >= 4) {
-    return "白银会员";
-  }
-
-  return "普通会员";
-}
-
-function getMembershipColor(level: string) {
-  if (level === "黄金会员") {
+function getMembershipColor(level: Membership["level"]) {
+  if (level === "premium") {
     return "#f59e0b";
   }
 
-  if (level === "白银会员") {
+  if (level === "pro") {
+    return "#2563eb";
+  }
+
+  if (level === "basic") {
     return "#64748b";
   }
 
-  return "#2563eb";
+  return "#64748b";
+}
+
+function getMembershipStatusTag(status: Membership["status"]) {
+  if (status === "active") {
+    return { color: "success" as const, label: "账号正常" };
+  }
+
+  if (status === "expired") {
+    return { color: "warning" as const, label: "会员过期" };
+  }
+
+  return { color: "error" as const, label: "账号暂停" };
 }
 
 export default function UsersPage() {
@@ -140,6 +138,7 @@ export default function UsersPage() {
   const [detailUserId, setDetailUserId] = useState<string | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [detail, setDetail] = useState<UserDetail | null>(null);
+  const [membership, setMembership] = useState<Membership | null>(null);
   const [savingQuota, setSavingQuota] = useState(false);
   const [quotaValue, setQuotaValue] = useState<number>(0);
   const [form] = Form.useForm();
@@ -166,11 +165,15 @@ export default function UsersPage() {
       setDetailLoading(true);
 
       try {
-        const result = await api.getUserDetail(userId);
+        const [result, membershipResult] = await Promise.all([
+          api.getUserDetail(userId),
+          api.getMembership(userId),
+        ]);
         if (!cancelled) {
           const nextDetail = result as UserDetail;
           setDetail(nextDetail);
-          setQuotaValue(nextDetail.user.avatarQuota);
+          setMembership(membershipResult);
+          setQuotaValue(membershipResult.avatarQuotaTotal);
         }
       } catch (e) {
         if (!cancelled) {
@@ -206,10 +209,14 @@ export default function UsersPage() {
       setEditingId(null);
       load();
       if (currentEditingId && detailUserId === currentEditingId) {
-        const result = await api.getUserDetail(currentEditingId);
+        const [result, membershipResult] = await Promise.all([
+          api.getUserDetail(currentEditingId),
+          api.getMembership(currentEditingId),
+        ]);
         const nextDetail = result as UserDetail;
         setDetail(nextDetail);
-        setQuotaValue(nextDetail.user.avatarQuota);
+        setMembership(membershipResult);
+        setQuotaValue(membershipResult.avatarQuotaTotal);
       }
     } catch (e: any) {
       if (e.message) {
@@ -231,6 +238,7 @@ export default function UsersPage() {
       if (detailUserId === id) {
         setDetailUserId(null);
         setDetail(null);
+        setMembership(null);
       }
       load();
     } catch (e: any) {
@@ -243,15 +251,25 @@ export default function UsersPage() {
   };
 
   const handleSaveQuota = async () => {
-    if (!detail) {
+    if (!detail || !membership) {
       return;
     }
 
     setSavingQuota(true);
 
     try {
-      await api.updateUser(detail.user.id, { avatarQuota: quotaValue });
+      const nextMembership = await api.updateMembership(detail.user.id, {
+        level: membership.level,
+        status: membership.status,
+        expireAt: membership.expireAt,
+        benefits:
+          membership.benefits.length > 0
+            ? membership.benefits
+            : DEFAULT_FREE_BENEFITS.map((benefit) => ({ ...benefit })),
+        avatarQuotaTotal: quotaValue,
+      });
       message.success("配额已保存");
+      setMembership(nextMembership);
       const nextDetail = {
         ...detail,
         user: {
@@ -346,13 +364,13 @@ export default function UsersPage() {
   const listSelectedUser = data.find((item) => item.id === detailUserId) ?? null;
 
   const membershipLevel = useMemo(
-    () => (detailUser ? getMembershipLevel(detailUser.avatarQuota) : "普通会员"),
-    [detailUser],
+    () => membership?.levelLabel ?? "免费版",
+    [membership],
   );
 
   const membershipExpireAt = useMemo(
-    () => (detailUser ? dayjs(detailUser.createdAt).add(1, "year").format("YYYY-MM-DD") : "-"),
-    [detailUser],
+    () => (membership?.expireAt ? dayjs(membership.expireAt).format("YYYY-MM-DD") : "-"),
+    [membership],
   );
 
   const boundDevices = useMemo(
@@ -369,6 +387,15 @@ export default function UsersPage() {
     () => (detailUser ? buildDisplayUserCode(detailUser) : "-"),
     [detailUser],
   );
+  const membershipStatusMeta = membership ? getMembershipStatusTag(membership.status) : getMembershipStatusTag("active");
+  const membershipBenefits = useMemo(
+    () =>
+      membership?.benefits && membership.benefits.length > 0
+        ? membership.benefits
+        : DEFAULT_FREE_BENEFITS.map((benefit) => ({ ...benefit })),
+    [membership],
+  );
+  const remainingQuota = Math.max(0, quotaValue - (membership?.avatarQuotaUsed ?? 0));
 
   if (detailUserId && detailUser) {
     return (
@@ -429,8 +456,8 @@ export default function UsersPage() {
                     </div>
 
                     <div style={{ textAlign: "right" }}>
-                      <Tag color="success" style={{ marginInlineEnd: 0, paddingInline: 12, lineHeight: "24px", borderRadius: 999, fontSize: 12 }}>
-                        ● 账号正常
+                      <Tag color={membershipStatusMeta.color} style={{ marginInlineEnd: 0, paddingInline: 12, lineHeight: "24px", borderRadius: 999, fontSize: 12 }}>
+                        {`● ${membershipStatusMeta.label}`}
                       </Tag>
                       <div style={{ marginTop: 12 }}>
                         <Text type="secondary" style={{ fontSize: 13 }}>{`注册时间: ${dayjs(detailUser.createdAt).format("YYYY-MM-DD")}`}</Text>
@@ -448,7 +475,7 @@ export default function UsersPage() {
                     <div style={{ padding: 14, borderRadius: 12, background: "#fff" }}>
                       <Text type="secondary" style={{ fontSize: 13 }}>会员等级</Text>
                       <div style={{ marginTop: 8 }}>
-                        <Text strong style={{ fontSize: 16, color: getMembershipColor(membershipLevel) }}>
+                        <Text strong style={{ fontSize: 16, color: getMembershipColor(membership?.level ?? "free") }}>
                           {membershipLevel}
                         </Text>
                       </div>
@@ -488,7 +515,7 @@ export default function UsersPage() {
                         定制额度
                       </Title>
                       <div style={{ marginTop: 6 }}>
-                        <Text type="secondary" style={{ fontSize: 13 }}>{`剩余免费次数: ${Math.max(0, quotaValue)} 次 / 共 15 次`}</Text>
+                        <Text type="secondary" style={{ fontSize: 13 }}>{`剩余免费次数: ${remainingQuota} 次 / 共 ${quotaValue} 次`}</Text>
                       </div>
                     </div>
 
@@ -511,9 +538,9 @@ export default function UsersPage() {
                     </Text>
 
                     <Space direction="vertical" size={10} style={{ display: "flex" }}>
-                      {membershipPerks.map((perk) => (
+                      {membershipBenefits.map((perk: MembershipBenefit) => (
                         <div
-                          key={perk.label}
+                          key={perk.key}
                           style={{
                             padding: "12px 14px",
                             borderRadius: 12,
@@ -524,7 +551,7 @@ export default function UsersPage() {
                           }}
                         >
                           <CheckSquareFilled style={{ color: perk.enabled ? "#10b981" : "#cbd5e1", fontSize: 18 }} />
-                          <Text style={{ fontSize: 14 }}>{perk.label}</Text>
+                          <Text style={{ fontSize: 14 }}>{perk.value ? `${perk.label} · ${perk.value}` : perk.label}</Text>
                         </div>
                       ))}
                     </Space>


### PR DESCRIPTION
## 变更说明

本次 PR 主要是把管理后台前端对齐到后端最新接口，并补齐本轮页面联调中需要的展示与交互。

### 包含内容

- 设备管理页改为统一走最新设备接口
  - 列表使用 `GET /api/admin/devices`
  - 详情使用 `GET /api/admin/devices/:type/:id/detail`
- 用户会员详情改为接入会员接口
  - 使用 `GET /api/admin/users/:id/membership`
  - 使用 `PUT /api/admin/users/:id/membership`
- 定制中心接入最新任务接口与上传链路
  - 使用 `GET /api/admin/customization/tasks`
  - 接入 `POST /api/admin/uploads/presign`
  - 保留 URL 输入作为兜底
- 图像审核页接入统计接口
  - 使用 `GET /api/admin/avatar-review/stats`
- 修复用户会员详情页权益丢失问题
  - 当 `benefits` 为空时回退默认权益，避免页面空白

## 影响文件

- `packages/admin/src/api/client.ts`
- `packages/admin/src/pages/Devices.tsx`
- `packages/admin/src/pages/Users.tsx`
- `packages/admin/src/pages/Customization.tsx`
- `packages/admin/src/pages/ImageReview.tsx`

## 验证结果

已本地验证：

- `pnpm --filter admin build` 通过
- `pnpm --filter server test` 通过（126 pass）

当前仍存在的后端问题已单独记录到：

- #72

## 备注

这版代码已经可以给后端拉取并继续一起联调。
