### PR TITLE
fix(server): 修正预检迁移表 schema

### DIFF
--- a/packages/server/src/preflight.ts
+++ b/packages/server/src/preflight.ts
@@ -98,7 +98,7 @@ export async function checkMigrations(): Promise<void> {
     const [{ db }, journal] = await Promise.all([import("./db/index"), readMigrationJournal()]);
     const rows = await db.execute<{ count: number }>(sql`
       SELECT COUNT(*)::int AS count
-      FROM __drizzle_migrations
+      FROM drizzle.__drizzle_migrations
     `);
     const appliedCount = Number(rows[0]?.count ?? 0);
     const expectedCount = journal.entries?.length ?? 0;


### PR DESCRIPTION
## Summary
- `checkMigrations()` 查询的是 `public.__drizzle_migrations`，但 drizzle-kit 实际把记录写在 `drizzle` schema 下，导致每次启动都打印 `⚠️ 数据库迁移检查失败: relation "__drizzle_migrations" does not exist`
- 将 SQL 改为查询 `drizzle.__drizzle_migrations`

## Test plan
- [ ] 部署后观察 server 启动日志输出 `ℹ️ 已应用 N 个数据库迁移`，不再报 warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)