### PR TITLE
chore: 接入 watchtower 自动部署 + 镜像清理

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -55,12 +55,29 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
 
   admin:
     image: ghcr.io/thup-jds/pet-wechat/admin:latest
     restart: unless-stopped
     ports:
       - "9528:80"
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+
+  watchtower:
+    image: containrrr/watchtower
+    restart: unless-stopped
+    environment:
+      WATCHTOWER_CLEANUP: "true"
+      WATCHTOWER_INCLUDE_RESTARTING: "true"
+      WATCHTOWER_POLL_INTERVAL: "300"
+      WATCHTOWER_LABEL_ENABLE: "true"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
 
 volumes:
   pg_data:


### PR DESCRIPTION
## Summary
- 新增 watchtower 服务，每 5 分钟轮询 ghcr.io 上的 server / admin 镜像，有新版自动 pull + 重启
- 开启 \`WATCHTOWER_CLEANUP\`：更新后自动删除旧镜像，避免磁盘堆积
- 通过 label 白名单（\`WATCHTOWER_LABEL_ENABLE\`）只管 server / admin / watchtower 自身，不动 postgres / minio

## Test plan
- [ ] hk 上 \`docker compose -f docker-compose.prod.yml pull && up -d\` 起来后 \`docker ps\` 能看到 watchtower
- [ ] 后续推 main 触发 build-images workflow，观察 watchtower 日志是否拉到新镜像并重启 server / admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)