### PR TITLE
fix: 切换到 nickfedor/watchtower fork（兼容新版 docker daemon）

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -67,7 +67,7 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
   watchtower:
-    image: containrrr/watchtower
+    image: nickfedor/watchtower:latest
     restart: unless-stopped
     environment:
       WATCHTOWER_CLEANUP: "true"


### PR DESCRIPTION
## Summary
\`containrrr/watchtower\` 已基本停止维护，其 client API 太旧，hk 上 docker daemon 29.x 已不支持，导致 watchtower 容器持续重启。换成活跃维护的 \`nickfedor/watchtower\` fork。

🤖 Generated with [Claude Code](https://claude.com/claude-code)