### PR TITLE
chore(server): 启动前自动执行数据库迁移

### DIFF
--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -15,4 +15,4 @@ RUN sed -i 's/"shared": "workspace:\*"/"shared": "file:..\/shared"/' package.jso
 
 EXPOSE 9527
 
-CMD ["bun", "src/index.ts"]
+CMD ["bun", "run", "start"]

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun --watch src/index.ts",
-    "start": "bun src/index.ts",
+    "start": "drizzle-kit migrate && bun src/index.ts",
     "build": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",


### PR DESCRIPTION
## 背景
每次部署完后还要手动跑 \`pnpm db:migrate\`，容易漏。

## 修改
- \`packages/server/package.json\`：\`start\` 改为 \`drizzle-kit migrate && bun src/index.ts\`
- \`packages/server/Dockerfile\`：\`CMD\` 改为 \`bun run start\`，复用同一脚本

## 验证
- \`drizzle.config.ts\` 已从 \`DATABASE_URL\` 读取连接，compose 里也已注入
- \`drizzle-kit\` 是 devDependency，但 Dockerfile 的 \`bun install\` 默认会装上，runtime 可用
- 迁移幂等，重复启动安全

🤖 Generated with [Claude Code](https://claude.com/claude-code)