### PR TITLE
feat: 摆台资源清单接口与管理员视频上传

### DIFF
--- a/packages/admin/src/api/client.ts
+++ b/packages/admin/src/api/client.ts
@@ -125,6 +125,32 @@ async function uploadAdminAsset(
   return res.json();
 }
 
+async function uploadAvatarActionVideo(avatarId: string, actionId: string, file: File): Promise<{ action: any }> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const res = await fetch(`/api/admin/avatars/${avatarId}/actions/${actionId}/video`, {
+    method: "POST",
+    headers: {
+      "X-Admin-Key": getAdminKey(),
+    },
+    body: formData,
+  });
+
+  if (res.status === 401) {
+    localStorage.removeItem("adminKey");
+    window.location.reload();
+    throw new Error("Admin Key 无效");
+  }
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error(err.error || res.statusText);
+  }
+
+  return res.json();
+}
+
 export const api = {
   // Stats
   getStats: () => request<Record<string, number>>("/stats"),
@@ -174,6 +200,7 @@ export const api = {
   createAvatarAction: (id: string, data: { actionType: string; imageUrl: string }) =>
     request<{ action: any }>(`/avatars/${id}/actions`, { method: "POST", body: JSON.stringify(data) }),
   deleteAvatarAction: (id: string, actionId: string) => request(`/avatars/${id}/actions/${actionId}`, { method: "DELETE" }),
+  uploadAvatarActionVideo,
   updateAvatarMeta: (id: string, data: { petDescription?: string; funFact?: string }) =>
     request<{ avatar: any }>(`/avatars/${id}/meta`, { method: "PUT", body: JSON.stringify(data) }),
   syncAvatar: (id: string) => request<{ avatar: any }>(`/avatars/${id}/sync`, { method: "POST" }),

--- a/packages/admin/src/pages/Customization.tsx
+++ b/packages/admin/src/pages/Customization.tsx
@@ -663,7 +663,7 @@ export default function Customization() {
   const canSync = !!selectedAvatarDetail && uploadedProgress.completed > 0 && selectedAvatarDetail.status !== "done";
 
   const previewAction = previewActionType ? actionMap[previewActionType] : undefined;
-  const previewImageUrl = previewAction?.imageUrl ?? selectedAvatarDetail?.sourceImageUrl ?? selectedAvatarSummary?.sourceImageUrl ?? "";
+  const previewImageUrl = previewAction?.videoUrl ?? previewAction?.imageUrl ?? selectedAvatarDetail?.sourceImageUrl ?? selectedAvatarSummary?.sourceImageUrl ?? "";
   const selectedAvatarImage =
     selectedAvatarDetail?.sourceImageUrl ?? selectedAvatarSummary?.sourceImageUrl ?? "";
   const referenceImages = parseAdditionalImages(
@@ -735,10 +735,15 @@ export default function Customization() {
         return;
       }
 
-      await api.createAvatarAction(selectedAvatarDetail.id, {
+      const actionResult = await api.createAvatarAction(selectedAvatarDetail.id, {
         actionType: uploadActionType,
         imageUrl,
       });
+
+      if (uploadFile && actionResult.action?.id) {
+        await api.uploadAvatarActionVideo(selectedAvatarDetail.id, actionResult.action.id, uploadFile);
+      }
+
       messageApi.success("动作素材已上传");
       handleCloseUploadModal();
       await refreshCurrentAvatar(selectedAvatarDetail.id);
@@ -845,7 +850,7 @@ export default function Customization() {
               >
                 {action ? (
                   <video
-                    src={action.imageUrl}
+                    src={action.videoUrl ?? action.imageUrl}
                     controls
                     preload="metadata"
                     playsInline

--- a/packages/server/drizzle/0010_needy_cardiac.sql
+++ b/packages/server/drizzle/0010_needy_cardiac.sql
@@ -1,0 +1,7 @@
+ALTER TYPE "public"."device_claim_status" ADD VALUE 'unclaimed' BEFORE 'reset_required';--> statement-breakpoint
+ALTER TABLE "collar_devices" ADD COLUMN "chip_id" text;--> statement-breakpoint
+ALTER TABLE "desktop_devices" ADD COLUMN "chip_id" text;--> statement-breakpoint
+ALTER TABLE "pet_avatar_actions" ADD COLUMN "video_url" text;--> statement-breakpoint
+ALTER TABLE "pet_avatar_actions" ADD COLUMN "video_hash" text;--> statement-breakpoint
+ALTER TABLE "collar_devices" ADD CONSTRAINT "collar_devices_chip_id_unique" UNIQUE("chip_id");--> statement-breakpoint
+ALTER TABLE "desktop_devices" ADD CONSTRAINT "desktop_devices_chip_id_unique" UNIQUE("chip_id");

--- a/packages/server/drizzle/meta/0010_snapshot.json
+++ b/packages/server/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1678 @@
+{
+  "id": "8ff27079-966d-4c27-bafc-077888695253",
+  "prevId": "139fbd11-479a-48d4-8c72-9206d01e615b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.behavior_schedule_blocks": {
+      "name": "behavior_schedule_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_minutes": {
+          "name": "start_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_minutes": {
+          "name": "end_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "behavior_schedule_blocks_schedule_id_behavior_schedules_id_fk": {
+          "name": "behavior_schedule_blocks_schedule_id_behavior_schedules_id_fk",
+          "tableFrom": "behavior_schedule_blocks",
+          "tableTo": "behavior_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "behavior_schedule_blocks_start_minutes_check": {
+          "name": "behavior_schedule_blocks_start_minutes_check",
+          "value": "\"behavior_schedule_blocks\".\"start_minutes\" >= 0 AND \"behavior_schedule_blocks\".\"start_minutes\" < 1440"
+        },
+        "behavior_schedule_blocks_end_minutes_check": {
+          "name": "behavior_schedule_blocks_end_minutes_check",
+          "value": "\"behavior_schedule_blocks\".\"end_minutes\" > 0 AND \"behavior_schedule_blocks\".\"end_minutes\" <= 1440"
+        },
+        "behavior_schedule_blocks_range_check": {
+          "name": "behavior_schedule_blocks_range_check",
+          "value": "\"behavior_schedule_blocks\".\"start_minutes\" < \"behavior_schedule_blocks\".\"end_minutes\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.behavior_schedules": {
+      "name": "behavior_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_type": {
+          "name": "effective_type",
+          "type": "schedule_effective_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'everyday'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "behavior_schedules_active_unique": {
+          "name": "behavior_schedules_active_unique",
+          "columns": [
+            {
+              "expression": "species",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"behavior_schedules\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collar_devices": {
+      "name": "collar_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chip_id": {
+          "name": "chip_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mac_address": {
+          "name": "mac_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "battery": {
+          "name": "battery",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signal": {
+          "name": "signal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firmware_version": {
+          "name": "firmware_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_status": {
+          "name": "claim_status",
+          "type": "device_claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'occupied'"
+        },
+        "usage_duration_minutes": {
+          "name": "usage_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "upgrade_status": {
+          "name": "upgrade_status",
+          "type": "device_upgrade_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "last_online_at": {
+          "name": "last_online_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_collar_devices_pet_id": {
+          "name": "idx_collar_devices_pet_id",
+          "columns": [
+            {
+              "expression": "pet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collar_devices_chip_id_unique": {
+          "name": "collar_devices_chip_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chip_id"
+          ]
+        },
+        "collar_devices_mac_address_unique": {
+          "name": "collar_devices_mac_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mac_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.desktop_devices": {
+      "name": "desktop_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chip_id": {
+          "name": "chip_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mac_address": {
+          "name": "mac_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "firmware_version": {
+          "name": "firmware_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_status": {
+          "name": "claim_status",
+          "type": "device_claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'occupied'"
+        },
+        "usage_duration_minutes": {
+          "name": "usage_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "upgrade_status": {
+          "name": "upgrade_status",
+          "type": "device_upgrade_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "last_online_at": {
+          "name": "last_online_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "desktop_devices_chip_id_unique": {
+          "name": "desktop_devices_chip_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chip_id"
+          ]
+        },
+        "desktop_devices_mac_address_unique": {
+          "name": "desktop_devices_mac_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mac_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.desktop_pet_bindings": {
+      "name": "desktop_pet_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "desktop_device_id": {
+          "name": "desktop_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_type": {
+          "name": "binding_type",
+          "type": "binding_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unbound_at": {
+          "name": "unbound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_desktop_pet_bindings_device_created_at": {
+          "name": "idx_desktop_pet_bindings_device_created_at",
+          "columns": [
+            {
+              "expression": "desktop_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"desktop_pet_bindings\".\"unbound_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_desktop_pet_bindings_pet_id": {
+          "name": "idx_desktop_pet_bindings_pet_id",
+          "columns": [
+            {
+              "expression": "pet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"desktop_pet_bindings\".\"unbound_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_authorizations": {
+      "name": "device_authorizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "authorization_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'accepted'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_authorizations_from_user_id_to_user_id_pet_id_unique": {
+          "name": "device_authorizations_from_user_id_to_user_id_pet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "from_user_id",
+            "to_user_id",
+            "pet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.firmware_releases": {
+      "name": "firmware_releases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "device_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_notes": {
+          "name": "release_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_firmware_releases_device_type_version": {
+          "name": "uq_firmware_releases_device_type_version",
+          "columns": [
+            {
+              "expression": "device_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_firmware_releases_device_type_released_at": {
+          "name": "idx_firmware_releases_device_type_released_at",
+          "columns": [
+            {
+              "expression": "device_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "released_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interaction_events": {
+      "name": "interaction_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_interaction_events_pet_occurred_at": {
+          "name": "idx_interaction_events_pet_occurred_at",
+          "columns": [
+            {
+              "expression": "pet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_interaction_events_user_occurred_at": {
+          "name": "idx_interaction_events_user_occurred_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_interaction_events_device_occurred_at": {
+          "name": "idx_interaction_events_device_occurred_at",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interaction_events_user_id_users_id_fk": {
+          "name": "interaction_events_user_id_users_id_fk",
+          "tableFrom": "interaction_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interaction_events_pet_id_pets_id_fk": {
+          "name": "interaction_events_pet_id_pets_id_fk",
+          "tableFrom": "interaction_events",
+          "tableTo": "pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_codes_code_hash_unique": {
+          "name": "invite_codes_code_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "membership_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "status": {
+          "name": "status",
+          "type": "membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expire_at": {
+          "name": "expire_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_memberships_user_id": {
+          "name": "uq_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pet_avatar_actions": {
+      "name": "pet_avatar_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_avatar_id": {
+          "name": "pet_avatar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_hash": {
+          "name": "video_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_pet_avatar_actions_avatar_sort_order": {
+          "name": "idx_pet_avatar_actions_avatar_sort_order",
+          "columns": [
+            {
+              "expression": "pet_avatar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pet_avatars": {
+      "name": "pet_avatars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_image_url": {
+          "name": "source_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additional_image_urls": {
+          "name": "additional_image_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pet_description": {
+          "name": "pet_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fun_fact": {
+          "name": "fun_fact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "avatar_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reject_reason": {
+          "name": "reject_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pet_avatars_pet_created_at": {
+          "name": "idx_pet_avatars_pet_created_at",
+          "columns": [
+            {
+              "expression": "pet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pet_behaviors": {
+      "name": "pet_behaviors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collar_device_id": {
+          "name": "collar_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pets": {
+      "name": "pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_score": {
+          "name": "activity_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_enabled": {
+          "name": "message_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sound_enabled": {
+          "name": "sound_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "user_setting_theme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "language": {
+          "name": "language",
+          "type": "user_setting_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'zh-CN'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wechat_openid": {
+          "name": "wechat_openid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_quota": {
+          "name": "avatar_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_wechat_openid_unique": {
+          "name": "users_wechat_openid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wechat_openid"
+          ]
+        },
+        "users_phone_unique": {
+          "name": "users_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.authorization_status": {
+      "name": "authorization_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.avatar_status": {
+      "name": "avatar_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "done",
+        "failed",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.binding_type": {
+      "name": "binding_type",
+      "schema": "public",
+      "values": [
+        "owner",
+        "authorized"
+      ]
+    },
+    "public.device_claim_status": {
+      "name": "device_claim_status",
+      "schema": "public",
+      "values": [
+        "occupied",
+        "available",
+        "unclaimed",
+        "reset_required"
+      ]
+    },
+    "public.device_status": {
+      "name": "device_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline",
+        "pairing"
+      ]
+    },
+    "public.device_type": {
+      "name": "device_type",
+      "schema": "public",
+      "values": [
+        "collar",
+        "desktop"
+      ]
+    },
+    "public.device_upgrade_status": {
+      "name": "device_upgrade_status",
+      "schema": "public",
+      "values": [
+        "idle",
+        "pending",
+        "success",
+        "failed"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "unknown"
+      ]
+    },
+    "public.membership_level": {
+      "name": "membership_level",
+      "schema": "public",
+      "values": [
+        "free",
+        "basic",
+        "pro",
+        "premium"
+      ]
+    },
+    "public.membership_status": {
+      "name": "membership_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "suspended"
+      ]
+    },
+    "public.message_type": {
+      "name": "message_type",
+      "schema": "public",
+      "values": [
+        "authorization",
+        "system"
+      ]
+    },
+    "public.schedule_effective_type": {
+      "name": "schedule_effective_type",
+      "schema": "public",
+      "values": [
+        "everyday",
+        "weekday",
+        "friday"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "cat",
+        "dog"
+      ]
+    },
+    "public.user_setting_language": {
+      "name": "user_setting_language",
+      "schema": "public",
+      "values": [
+        "zh-CN",
+        "zh-TW",
+        "en-US"
+      ]
+    },
+    "public.user_setting_theme": {
+      "name": "user_setting_theme",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark",
+        "blue"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1776441074827,
       "tag": "0008_empty_sharon_carter",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1777887838570,
+      "tag": "0010_needy_cardiac",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/admin-avatar-review.test.ts
+++ b/packages/server/src/__tests__/admin-avatar-review.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import { Hono } from "hono";
 import avatarsRoute from "../routes/admin/avatars";
-import { jsonReq } from "./helpers";
+import { fakeAvatar, fakeAvatarAction, jsonReq } from "./helpers";
 import { mockDb } from "./setup";
 
 const app = new Hono();
@@ -33,6 +33,53 @@ describe("Admin Avatar Review Routes", () => {
       syncedToDevices: 5,
       todayNewUploads: 4,
       todayCompleted: 6,
+    });
+  });
+
+  it("uploads an action video and stores sha256", async () => {
+    const avatar = fakeAvatar({ id: "avatar-1", petId: "pet-1", status: "processing" });
+    const action = fakeAvatarAction({ id: "action-1", petAvatarId: "avatar-1", actionType: "lay" });
+    const updatedAction = {
+      ...action,
+      videoUrl: "https://test-storage.local/avatars/avatar-1/lay.mjpeg",
+      videoHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+    };
+
+    mockDb._results.select = [
+      [{
+        avatar,
+        petId: "pet-1",
+        petName: "Mimi",
+        petSpecies: "cat",
+        petBreed: null,
+        petGender: "unknown",
+        petBirthday: null,
+        petWeight: null,
+        userId: "user-1",
+        userNickname: "Test User",
+        userAvatarUrl: null,
+        userWechatOpenid: null,
+        userPhone: null,
+      }],
+      [action],
+    ];
+    mockDb._results.update = [[updatedAction]];
+
+    const formData = new FormData();
+    formData.append("file", new File(["hello"], "lay.mjpeg", { type: "video/mjpeg" }));
+
+    const res = await app.request(
+      new Request("http://localhost/api/admin/avatars/avatar-1/actions/action-1/video", {
+        method: "POST",
+        body: formData,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ action: updatedAction });
+    expect((mockDb._calls.update[0] as any).set).toEqual({
+      videoUrl: "https://test-storage.local/avatars/avatar-1/lay.mjpeg",
+      videoHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
     });
   });
 });

--- a/packages/server/src/__tests__/device-report.test.ts
+++ b/packages/server/src/__tests__/device-report.test.ts
@@ -2,6 +2,8 @@ import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import { mockDb } from "./setup";
 import {
   createApp,
+  fakeAvatar,
+  fakeAvatarAction,
   fakeBehavior,
   fakeBinding,
   fakeCollar,
@@ -30,6 +32,122 @@ describe("Device Report Routes", () => {
     }
 
     process.env.DEVICE_REPORT_SECRET = originalDeviceReportSecret;
+  });
+
+  describe("GET /api/device-report/tabletop/manifest", () => {
+    it("auto creates an unclaimed desktop for unknown chipId", async () => {
+      mockDb._results.select = [[], []];
+      mockDb._results.insert = [[fakeDesktop({ id: "desktop-new", chipId: "8c4718feff49fd8c" })]];
+
+      const res = await app.request(
+        jsonReq("GET", "/api/device-report/tabletop/manifest?chipId=8c4718feff49fd8c"),
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ collarChipId: null, files: [] });
+      expect((mockDb._calls.insert[0] as any).values).toMatchObject({
+        name: "摆台-49fd8c",
+        chipId: "8c4718feff49fd8c",
+        macAddress: "8c4718feff49fd8c",
+        claimStatus: "unclaimed",
+      });
+    });
+
+    it("returns empty files for an existing desktop without pet binding", async () => {
+      mockDb._results.select = [
+        [fakeDesktop({ chipId: "desktop-chip-1" })],
+        [],
+      ];
+
+      const res = await app.request(
+        jsonReq("GET", "/api/device-report/tabletop/manifest?chipId=desktop-chip-1"),
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ collarChipId: null, files: [] });
+      expect(mockDb._calls.insert).toHaveLength(0);
+    });
+
+    it("returns collar chipId and avatar video files for bound pet", async () => {
+      mockDb._results.select = [
+        [fakeDesktop({ id: "desktop-1", chipId: "desktop-chip-1" })],
+        [fakeBinding({ desktopDeviceId: "desktop-1", petId: "pet-1" })],
+        [fakeCollar({ petId: "pet-1", chipId: "collar-chip-1" })],
+        [fakeAvatar({ id: "avatar-1", petId: "pet-1", status: "approved" })],
+        [
+          fakeAvatarAction({
+            petAvatarId: "avatar-1",
+            actionType: "lay",
+            videoUrl: "https://pet-wechat.yangl.com.cn/storage/avatars/avatar-1/lay.mjpeg",
+            videoHash: "sha256-lay",
+          }),
+        ],
+      ];
+
+      const res = await app.request(
+        jsonReq("GET", "/api/device-report/tabletop/manifest?chipId=desktop-chip-1"),
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        collarChipId: "collar-chip-1",
+        files: [
+          {
+            path: "/avatar/lay.mjpeg",
+            hash: "sha256-lay",
+            url: "https://pet-wechat.yangl.com.cn/storage/avatars/avatar-1/lay.mjpeg",
+          },
+        ],
+      });
+    });
+
+    it("returns null collarChipId when no collar is bound to the pet", async () => {
+      mockDb._results.select = [
+        [fakeDesktop({ id: "desktop-1", chipId: "desktop-chip-1" })],
+        [fakeBinding({ desktopDeviceId: "desktop-1", petId: "pet-1" })],
+        [],
+        [fakeAvatar({ id: "avatar-1", petId: "pet-1", status: "approved" })],
+        [
+          fakeAvatarAction({
+            petAvatarId: "avatar-1",
+            videoUrl: "https://pet-wechat.yangl.com.cn/storage/avatars/avatar-1/lay.mjpeg",
+            videoHash: "sha256-lay",
+          }),
+        ],
+      ];
+
+      const res = await app.request(
+        jsonReq("GET", "/api/device-report/tabletop/manifest?chipId=desktop-chip-1"),
+      );
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).collarChipId).toBeNull();
+    });
+
+    it("ignores avatar actions without video", async () => {
+      mockDb._results.select = [
+        [fakeDesktop({ id: "desktop-1", chipId: "desktop-chip-1" })],
+        [fakeBinding({ desktopDeviceId: "desktop-1", petId: "pet-1" })],
+        [fakeCollar({ petId: "pet-1", chipId: "collar-chip-1" })],
+        [fakeAvatar({ id: "avatar-1", petId: "pet-1", status: "approved" })],
+        [fakeAvatarAction({ petAvatarId: "avatar-1", videoUrl: null, videoHash: null })],
+      ];
+
+      const res = await app.request(
+        jsonReq("GET", "/api/device-report/tabletop/manifest?chipId=desktop-chip-1"),
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ collarChipId: "collar-chip-1", files: [] });
+    });
+
+    it("returns 400 when chipId is missing or blank", async () => {
+      const missing = await app.request(jsonReq("GET", "/api/device-report/tabletop/manifest"));
+      const blank = await app.request(jsonReq("GET", "/api/device-report/tabletop/manifest?chipId=%20"));
+
+      expect(missing.status).toBe(400);
+      expect(blank.status).toBe(400);
+    });
   });
 
   describe("POST /api/device-report/heartbeat", () => {

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -122,6 +122,7 @@ export function fakeCollar(overrides: Record<string, unknown> = {}) {
     userId: "user-1",
     petId: "pet-1",
     name: "My Collar",
+    chipId: "collar-chip-1",
     macAddress: "AA:BB:CC:DD:EE:FF",
     status: "offline",
     battery: null,
@@ -142,6 +143,7 @@ export function fakeDesktop(overrides: Record<string, unknown> = {}) {
     id: "desktop-1",
     userId: "user-1",
     name: "My Desktop",
+    chipId: "desktop-chip-1",
     macAddress: "11:22:33:44:55:66",
     status: "offline",
     firmwareVersion: null,
@@ -173,8 +175,26 @@ export function fakeAvatar(overrides: Record<string, unknown> = {}) {
     id: "avatar-1",
     petId: "pet-1",
     sourceImageUrl: "https://example.com/photo.jpg",
+    additionalImageUrls: null,
+    petDescription: null,
+    funFact: null,
     status: "pending",
+    rejectReason: null,
+    reviewedAt: null,
     createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+export function fakeAvatarAction(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "action-1",
+    petAvatarId: "avatar-1",
+    actionType: "lay",
+    imageUrl: "https://example.com/lay.jpg",
+    videoUrl: null,
+    videoHash: null,
+    sortOrder: 0,
     ...overrides,
   };
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -56,6 +56,7 @@ export const deviceTypeEnum = pgEnum("device_type", ["collar", "desktop"]);
 export const deviceClaimStatusEnum = pgEnum("device_claim_status", [
   "occupied",
   "available",
+  "unclaimed",
   "reset_required",
 ]);
 export const deviceUpgradeStatusEnum = pgEnum("device_upgrade_status", [
@@ -162,6 +163,7 @@ export const collarDevices = pgTable(
     userId: text("user_id"),
     petId: text("pet_id"),
     name: text("name").notNull(),
+    chipId: text("chip_id").unique(),
     macAddress: text("mac_address").notNull().unique(),
     status: deviceStatusEnum("status").notNull().default("offline"),
     battery: integer("battery"),
@@ -193,6 +195,7 @@ export const desktopDevices = pgTable("desktop_devices", {
   id: text("id").primaryKey().$defaultFn(createId),
   userId: text("user_id"),
   name: text("name").notNull(),
+  chipId: text("chip_id").unique(),
   macAddress: text("mac_address").notNull().unique(),
   status: deviceStatusEnum("status").notNull().default("offline"),
   firmwareVersion: text("firmware_version"),
@@ -300,6 +303,8 @@ export const petAvatarActions = pgTable(
     petAvatarId: text("pet_avatar_id").notNull(),
     actionType: text("action_type").notNull(),
     imageUrl: text("image_url").notNull(),
+    videoUrl: text("video_url"),
+    videoHash: text("video_hash"),
     sortOrder: integer("sort_order").notNull().default(0),
   },
   (table) => [

--- a/packages/server/src/routes/admin/avatars.ts
+++ b/packages/server/src/routes/admin/avatars.ts
@@ -1,9 +1,10 @@
+import { createHash } from "node:crypto";
 import { Hono } from "hono";
 import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { ALL_ACTIONS } from "shared";
 import { db } from "../../db";
 import { messages, petAvatars, petAvatarActions, pets, users } from "../../db/schema";
-import { isManagedStorageUrl, normalizePublicFileUrl } from "../../utils/storage";
+import { isManagedStorageUrl, normalizePublicFileUrl, uploadFile } from "../../utils/storage";
 import { broadcast } from "../../ws";
 
 const avatarsRoute = new Hono();
@@ -19,6 +20,8 @@ const VALID_AVATAR_STATUSES = new Set([
 const EDITABLE_ACTION_STATUSES = new Set(["approved", "processing"]);
 const VALID_ACTIONS = new Set<string>(ALL_ACTIONS);
 const ADMIN_TIME_ZONE = "Asia/Shanghai";
+const MAX_ACTION_VIDEO_SIZE = 50 * 1024 * 1024;
+const ACTION_VIDEO_TYPES = new Set(["video/mjpeg", "video/x-motion-jpeg"]);
 type AvatarStatus = (typeof petAvatars.$inferSelect)["status"];
 
 type AvatarRow = {
@@ -120,7 +123,20 @@ async function getAvatarActions(avatarId: string) {
   return actions.map((action) => ({
     ...action,
     imageUrl: normalizePublicFileUrl(action.imageUrl) ?? action.imageUrl,
+    videoUrl: normalizePublicFileUrl(action.videoUrl) ?? action.videoUrl,
   }));
+}
+
+function resolveActionVideoContentType(file: File) {
+  if (ACTION_VIDEO_TYPES.has(file.type)) {
+    return file.type;
+  }
+
+  if (/\.(mjpeg|mjpg)$/i.test(file.name)) {
+    return "video/mjpeg";
+  }
+
+  return null;
 }
 
 function getAvatarOwnerContext(row: AvatarRow) {
@@ -491,6 +507,71 @@ avatarsRoute.delete("/avatars/:id/actions/:actionId", async (c) => {
   });
 
   return c.json({ success: true });
+});
+
+avatarsRoute.post("/avatars/:id/actions/:actionId/video", async (c) => {
+  const avatarId = c.req.param("id");
+  const actionId = c.req.param("actionId");
+  const row = await getAvatarRow(avatarId);
+
+  if (!row) {
+    return c.json({ error: "Avatar not found" }, 404);
+  }
+
+  const [action] = await db
+    .select()
+    .from(petAvatarActions)
+    .where(and(eq(petAvatarActions.id, actionId), eq(petAvatarActions.petAvatarId, avatarId)))
+    .limit(1);
+
+  if (!action) {
+    return c.json({ error: "Action not found" }, 404);
+  }
+
+  try {
+    const body = await c.req.parseBody();
+    const file = body.file;
+
+    if (!file || typeof file === "string" || Array.isArray(file)) {
+      return c.json({ error: "未检测到上传文件" }, 400);
+    }
+
+    const uploadedFile = file as File;
+    const contentType = resolveActionVideoContentType(uploadedFile);
+
+    if (!contentType) {
+      return c.json({ error: "不支持的文件格式，请上传 MJPEG 文件" }, 400);
+    }
+
+    if (uploadedFile.size > MAX_ACTION_VIDEO_SIZE) {
+      return c.json({ error: "文件过大，请上传 50MB 以内的视频" }, 400);
+    }
+
+    const buffer = Buffer.from(await uploadedFile.arrayBuffer());
+    const videoHash = createHash("sha256").update(buffer).digest("hex");
+    const videoUrl = await uploadFile(
+      `avatars/${avatarId}/${action.actionType}.mjpeg`,
+      buffer,
+      contentType,
+    );
+
+    const [updatedAction] = await db
+      .update(petAvatarActions)
+      .set({ videoUrl, videoHash })
+      .where(and(eq(petAvatarActions.id, actionId), eq(petAvatarActions.petAvatarId, avatarId)))
+      .returning();
+
+    return c.json({
+      action: {
+        ...(updatedAction ?? action),
+        videoUrl,
+        videoHash,
+      },
+    });
+  } catch (error) {
+    console.error("Admin action video upload failed:", error);
+    return c.json({ error: "视频上传失败，请稍后重试" }, 503);
+  }
 });
 
 avatarsRoute.post("/avatars/:id/sync", async (c) => {

--- a/packages/server/src/routes/device-report.ts
+++ b/packages/server/src/routes/device-report.ts
@@ -1,5 +1,5 @@
 import { createHash, timingSafeEqual } from "node:crypto";
-import { and, desc, eq, isNull } from "drizzle-orm";
+import { and, asc, desc, eq, isNull } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 import { db } from "../db";
@@ -9,8 +9,11 @@ import {
   desktopDevices,
   desktopPetBindings,
   interactionEvents,
+  petAvatarActions,
+  petAvatars,
   petBehaviors,
 } from "../db/schema";
+import { normalizePublicFileUrl } from "../utils/storage";
 
 const deviceReportRoute = new Hono();
 
@@ -48,6 +51,10 @@ const eventBodySchema = z.object({
   type: deviceTypeSchema,
   actionType: z.string().trim().min(1).max(64),
   occurredAt: isoDatetimeSchema.optional(),
+});
+
+const manifestQuerySchema = z.object({
+  chipId: z.string().trim().min(1),
 });
 
 function toIsoString(value: Date | string | null | undefined): string | null {
@@ -93,7 +100,75 @@ async function findDesktopByMac(macAddress: string) {
   return desktop ?? null;
 }
 
+async function findDesktopByChipId(chipId: string) {
+  const [desktop] = await db
+    .select()
+    .from(desktopDevices)
+    .where(eq(desktopDevices.chipId, chipId));
+
+  return desktop ?? null;
+}
+
+async function getActiveDesktopPetId(desktopDeviceId: string) {
+  const [binding] = await db
+    .select()
+    .from(desktopPetBindings)
+    .where(
+      and(
+        eq(desktopPetBindings.desktopDeviceId, desktopDeviceId),
+        isNull(desktopPetBindings.unboundAt),
+      ),
+    )
+    .orderBy(desc(desktopPetBindings.createdAt))
+    .limit(1);
+
+  return binding?.petId ?? null;
+}
+
+async function getCollarChipId(petId: string) {
+  const [collar] = await db
+    .select()
+    .from(collarDevices)
+    .where(eq(collarDevices.petId, petId))
+    .orderBy(desc(collarDevices.createdAt))
+    .limit(1);
+
+  return collar?.chipId ?? null;
+}
+
+async function buildAvatarManifestFiles(petId: string) {
+  const [avatar] = await db
+    .select()
+    .from(petAvatars)
+    .where(and(eq(petAvatars.petId, petId), eq(petAvatars.status, "approved")))
+    .orderBy(desc(petAvatars.createdAt))
+    .limit(1);
+
+  if (!avatar) {
+    return [];
+  }
+
+  const actions = await db
+    .select()
+    .from(petAvatarActions)
+    .where(eq(petAvatarActions.petAvatarId, avatar.id))
+    .orderBy(asc(petAvatarActions.sortOrder), asc(petAvatarActions.actionType), asc(petAvatarActions.id));
+
+  return actions
+    .filter((action) => action.videoUrl && action.videoHash)
+    .map((action) => ({
+      path: `/avatar/${action.actionType}.mjpeg`,
+      hash: action.videoHash as string,
+      url: normalizePublicFileUrl(action.videoUrl) ?? action.videoUrl as string,
+    }));
+}
+
 deviceReportRoute.use("*", async (c, next) => {
+  if (c.req.path.endsWith("/tabletop/manifest")) {
+    await next();
+    return;
+  }
+
   const expectedSecret = process.env.DEVICE_REPORT_SECRET?.trim();
   if (!expectedSecret) {
     return c.json({ error: "Device report secret is not configured" }, 503);
@@ -105,6 +180,46 @@ deviceReportRoute.use("*", async (c, next) => {
   }
 
   await next();
+});
+
+deviceReportRoute.get("/tabletop/manifest", async (c) => {
+  const parsedQuery = manifestQuerySchema.safeParse({ chipId: c.req.query("chipId") });
+  if (!parsedQuery.success) {
+    return c.json({ error: "chipId is required" }, 400);
+  }
+
+  const { chipId } = parsedQuery.data;
+  let desktop = await findDesktopByChipId(chipId);
+
+  if (!desktop) {
+    const [createdDesktop] = await db
+      .insert(desktopDevices)
+      .values({
+        name: `摆台-${chipId.slice(-6)}`,
+        chipId,
+        macAddress: chipId,
+        claimStatus: "unclaimed",
+      })
+      .returning();
+
+    desktop = createdDesktop ?? null;
+  }
+
+  if (!desktop) {
+    return c.json({ collarChipId: null, files: [] });
+  }
+
+  const petId = await getActiveDesktopPetId(desktop.id);
+  if (!petId) {
+    return c.json({ collarChipId: null, files: [] });
+  }
+
+  const [collarChipId, files] = await Promise.all([
+    getCollarChipId(petId),
+    buildAvatarManifestFiles(petId),
+  ]);
+
+  return c.json({ collarChipId, files });
 });
 
 deviceReportRoute.post("/heartbeat", async (c) => {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -22,7 +22,7 @@ export type BindingType = "owner" | "authorized";
 export type AuthorizationStatus = "pending" | "accepted" | "rejected";
 export type ScheduleEffectiveType = "everyday" | "weekday" | "friday";
 export type DeviceType = "collar" | "desktop";
-export type DeviceClaimStatus = "occupied" | "available" | "reset_required";
+export type DeviceClaimStatus = "occupied" | "available" | "unclaimed" | "reset_required";
 export type DeviceUpgradeStatus = "idle" | "pending" | "success" | "failed";
 export type UserSettingTheme = "system" | "light" | "dark" | "blue";
 export type UserSettingLanguage = "zh-CN" | "zh-TW" | "en-US";
@@ -270,6 +270,8 @@ export interface PetAvatarAction {
   petAvatarId: string;
   actionType: string;
   imageUrl: string;
+  videoUrl?: string | null;
+  videoHash?: string | null;
   sortOrder: number;
 }
 


### PR DESCRIPTION
## Summary

- 新增 `GET /device-report/tabletop/manifest?chipId=xxx`（免鉴权），返回摆台绑定项圈的 chipId + 当前 avatar 的动作视频清单 `[{path, hash, url}]`，未注册 chipId 自动建 unclaimed 摆台记录
- 新增 `POST /api/admin/avatars/:id/actions/:actionId/video`，管理员可为某个 action 上传 mjpeg 视频，自动算 sha256 写入 video_hash
- schema 改动：`collar_devices.chip_id` / `desktop_devices.chip_id`（unique）、`pet_avatar_actions.video_url` + `video_hash`、`device_claim_status` 新增 `unclaimed`
- Admin 定制页支持上传 MJPEG 视频，预览优先使用 videoUrl

## Test plan

- [x] `pnpm --filter server typecheck`
- [x] `pnpm --filter shared build`
- [x] `pnpm --filter admin build`
- [x] `pnpm --filter server test`（153 通过）
- [x] 端到端集成验证（真实 Postgres + MinIO）：
  - [x] 缺/空 chipId → 400
  - [x] 全新 chipId → 自动建摆台、空清单
  - [x] 重复请求 → 幂等不重建
  - [x] 完整链路（摆台绑宠物 + 项圈绑同宠物 + 有视频）→ collarChipId 反查正确、files 只含有视频的 action
  - [x] 项圈解绑 / 项圈无 chipId → collarChipId=null
  - [x] avatar 状态 pending → files 空
  - [x] 摆台绑定 unbound → files 空
  - [x] admin 上传视频 → manifest 返回 url + hash → 实际下载文件 sha256 与 hash 完全一致

## 部署提醒

生产环境 `S3_PUBLIC_URL` 必须包含 bucket 路径或与 caddy `/storage` 反代规则一致，否则 manifest 返回的 url 缺 bucket 前缀会导致摆台 404。请上线前核对 HK 服务器现有配置。

## 硬件对接

摆台固件（参考 `astromnic-ai/pet-tabletop-mini`）需要把 `RESOURCE_API_URL` 改为：
\`\`\`
https://pet-wechat.yangl.com.cn/api/device-report/tabletop/manifest?chipId={chipId}
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)