### PR TITLE
feat(server): 摆台 manifest 用 actionType 替代 path

### DIFF
--- a/packages/server/src/__tests__/device-report.test.ts
+++ b/packages/server/src/__tests__/device-report.test.ts
@@ -93,7 +93,7 @@ describe("Device Report Routes", () => {
         collarChipId: "collar-chip-1",
         files: [
           {
-            path: "/avatar/lay.mjpeg",
+            actionType: "lay",
             hash: "sha256-lay",
             url: "https://pet-wechat.yangl.com.cn/storage/avatars/avatar-1/lay.mjpeg",
           },

--- a/packages/server/src/routes/device-report.ts
+++ b/packages/server/src/routes/device-report.ts
@@ -157,7 +157,7 @@ async function buildAvatarManifestFiles(petId: string) {
   return actions
     .filter((action) => action.videoUrl && action.videoHash)
     .map((action) => ({
-      path: `/avatar/${action.actionType}.mjpeg`,
+      actionType: action.actionType,
       hash: action.videoHash as string,
       url: normalizePublicFileUrl(action.videoUrl) ?? action.videoUrl as string,
     }));


### PR DESCRIPTION
## Summary

把 `/api/device-report/tabletop/manifest` 返回里 `files[].path: "/avatar/<actionType>.mjpeg"` 改成 `files[].actionType: "<actionType>"`。

固件原本得从字符串里反解出 actionType，现在直接拿字段，少一步解析。

## 改动前后

```diff
{
  "files": [
    {
-     "path": "/avatar/play_ball.mjpeg",
+     "actionType": "play_ball",
      "hash": "...",
      "url": "..."
    }
  ]
}
```

## Why now

manifest 接口刚上线（PR #86），目前只有摆台固件方一个消费者，且对方还在对接中——现在改字段名零破坏成本。再晚就只能加字段不能改名了。

## Test plan

- [x] `bun test device-report.test.ts` 全过（18 tests）
- [ ] CI build 绿
- [ ] 部署后用 mock chipId `AABBCCDDEE99` 验证返回

🤖 Generated with [Claude Code](https://claude.com/claude-code)