### PR TITLE
feat(server): manifest 返回所有 action 枚举值

### DIFF
--- a/packages/server/src/__tests__/device-report.test.ts
+++ b/packages/server/src/__tests__/device-report.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import { ALL_ACTIONS } from "shared";
 import { mockDb } from "./setup";
 import {
   createApp,
@@ -44,7 +45,7 @@ describe("Device Report Routes", () => {
       );
 
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual({ collarChipId: null, files: [] });
+      expect(await res.json()).toEqual({ collarChipId: null, files: [], allActionTypes: [...ALL_ACTIONS] });
       expect((mockDb._calls.insert[0] as any).values).toMatchObject({
         name: "摆台-49fd8c",
         chipId: "8c4718feff49fd8c",
@@ -64,7 +65,7 @@ describe("Device Report Routes", () => {
       );
 
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual({ collarChipId: null, files: [] });
+      expect(await res.json()).toEqual({ collarChipId: null, files: [], allActionTypes: [...ALL_ACTIONS] });
       expect(mockDb._calls.insert).toHaveLength(0);
     });
 
@@ -98,6 +99,7 @@ describe("Device Report Routes", () => {
             url: "https://pet-wechat.yangl.com.cn/storage/avatars/avatar-1/lay.mjpeg",
           },
         ],
+        allActionTypes: [...ALL_ACTIONS],
       });
     });
 
@@ -138,7 +140,7 @@ describe("Device Report Routes", () => {
       );
 
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual({ collarChipId: "collar-chip-1", files: [] });
+      expect(await res.json()).toEqual({ collarChipId: "collar-chip-1", files: [], allActionTypes: [...ALL_ACTIONS] });
     });
 
     it("returns 400 when chipId is missing or blank", async () => {

--- a/packages/server/src/routes/device-report.ts
+++ b/packages/server/src/routes/device-report.ts
@@ -2,6 +2,7 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import { and, asc, desc, eq, isNull } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
+import { ALL_ACTIONS } from "shared";
 import { db } from "../db";
 import { normalizeMac, NORMALIZED_MAC_REGEX } from "../utils/mac";
 import {
@@ -206,12 +207,12 @@ deviceReportRoute.get("/tabletop/manifest", async (c) => {
   }
 
   if (!desktop) {
-    return c.json({ collarChipId: null, files: [] });
+    return c.json({ collarChipId: null, files: [], allActionTypes: ALL_ACTIONS });
   }
 
   const petId = await getActiveDesktopPetId(desktop.id);
   if (!petId) {
-    return c.json({ collarChipId: null, files: [] });
+    return c.json({ collarChipId: null, files: [], allActionTypes: ALL_ACTIONS });
   }
 
   const [collarChipId, files] = await Promise.all([
@@ -219,7 +220,7 @@ deviceReportRoute.get("/tabletop/manifest", async (c) => {
     buildAvatarManifestFiles(petId),
   ]);
 
-  return c.json({ collarChipId, files });
+  return c.json({ collarChipId, files, allActionTypes: ALL_ACTIONS });
 });
 
 deviceReportRoute.post("/heartbeat", async (c) => {


### PR DESCRIPTION
## Summary

`/api/device-report/tabletop/manifest` 返回新增 `allActionTypes` 字段，把全部 14 个动作枚举值列出来。

```json
{
  "collarChipId": null,
  "files": [...],
  "allActionTypes": ["sit", "eat", "sleep", "lie", "run", "walk", "play_ball", "poop", "watch_tv", "chase_tail", "scratch_air", "dream", "lick_paw", "spin"]
}
```

## Why

摆台固件开发者拿到 manifest 时，`files` 里只有当前宠物已上传视频的 action。剩下的 enum 值要查源码或文档。直接附上完整清单，对接更直观。

## Test plan

- [x] `bun test device-report.test.ts` 全过（18 tests）
- [ ] 部署后用 mock chipId `AABBCCDDEE99` 验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)