### PR TITLE
feat(server): 支持动作素材 MJPEG 缩略图

### DIFF
--- a/packages/server/drizzle/0011_pet_avatar_action_backfill_video_url.sql
+++ b/packages/server/drizzle/0011_pet_avatar_action_backfill_video_url.sql
@@ -1,0 +1,4 @@
+UPDATE "pet_avatar_actions"
+SET "video_url" = "image_url"
+WHERE "video_url" IS NULL
+  AND "image_url" IS NOT NULL;

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1777887838570,
       "tag": "0010_needy_cardiac",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1777993374911,
+      "tag": "0011_pet_avatar_action_backfill_video_url",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/admin-avatar-review.test.ts
+++ b/packages/server/src/__tests__/admin-avatar-review.test.ts
@@ -6,6 +6,7 @@ import { mockDb } from "./setup";
 
 const app = new Hono();
 app.route("/api/admin", avatarsRoute);
+const TEST_MJPEG = new Uint8Array([0xff, 0xd8, 104, 101, 108, 108, 111, 0xff, 0xd9]);
 
 describe("Admin Avatar Review Routes", () => {
   beforeEach(() => {
@@ -41,8 +42,9 @@ describe("Admin Avatar Review Routes", () => {
     const action = fakeAvatarAction({ id: "action-1", petAvatarId: "avatar-1", actionType: "lay" });
     const updatedAction = {
       ...action,
+      imageUrl: "https://test-storage.local/avatars/avatar-1/lay-thumb.jpg",
       videoUrl: "https://test-storage.local/avatars/avatar-1/lay.mjpeg",
-      videoHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+      videoHash: "ac39d47c7b92ef8b2393ffff158c34707441867980f143f41f076b3bc8a6a6a1",
     };
 
     mockDb._results.select = [
@@ -66,7 +68,7 @@ describe("Admin Avatar Review Routes", () => {
     mockDb._results.update = [[updatedAction]];
 
     const formData = new FormData();
-    formData.append("file", new File(["hello"], "lay.mjpeg", { type: "video/mjpeg" }));
+    formData.append("file", new File([TEST_MJPEG], "lay.mjpeg", { type: "video/mjpeg" }));
 
     const res = await app.request(
       new Request("http://localhost/api/admin/avatars/avatar-1/actions/action-1/video", {
@@ -79,7 +81,8 @@ describe("Admin Avatar Review Routes", () => {
     expect(await res.json()).toEqual({ action: updatedAction });
     expect((mockDb._calls.update[0] as any).set).toEqual({
       videoUrl: "https://test-storage.local/avatars/avatar-1/lay.mjpeg",
-      videoHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+      videoHash: "ac39d47c7b92ef8b2393ffff158c34707441867980f143f41f076b3bc8a6a6a1",
+      imageUrl: "https://test-storage.local/avatars/avatar-1/lay-thumb.jpg",
     });
   });
 });

--- a/packages/server/src/__tests__/admin-uploads.test.ts
+++ b/packages/server/src/__tests__/admin-uploads.test.ts
@@ -5,6 +5,7 @@ import { jsonReq } from "./helpers";
 
 const app = new Hono();
 app.route("/api/admin", uploadsRoute);
+const TEST_MJPEG = new Uint8Array([0xff, 0xd8, 1, 2, 3, 0xff, 0xd9]);
 
 describe("Admin Upload Routes", () => {
   const originalEnableDevLogin = process.env.ENABLE_DEV_LOGIN;
@@ -51,7 +52,7 @@ describe("Admin Upload Routes", () => {
     formData.append("contentType", "video/x-motion-jpeg");
     formData.append(
       "file",
-      new File([new Uint8Array([1, 2, 3])], "base-sit-6.mjpeg", { type: "video/x-motion-jpeg" }),
+      new File([TEST_MJPEG], "base-sit-6.mjpeg", { type: "video/x-motion-jpeg" }),
     );
 
     const res = await app.request(
@@ -65,5 +66,6 @@ describe("Admin Upload Routes", () => {
     const json = await res.json();
     expect(json.url).toContain(".mjpeg");
     expect(json.url).toContain("uploads/admin/");
+    expect(json.thumbnailUrl).toContain("-thumb.jpg");
   });
 });

--- a/packages/server/src/__tests__/mjpeg.test.ts
+++ b/packages/server/src/__tests__/mjpeg.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { extractFirstJpegFrame } from "../utils/mjpeg";
+
+describe("extractFirstJpegFrame", () => {
+  it("extracts the first complete JPEG frame from multipart-like MJPEG bytes", () => {
+    const frame = Buffer.from([0xff, 0xd8, 1, 2, 3, 0xff, 0xd9]);
+    const buffer = Buffer.concat([
+      Buffer.from("--frame\r\nContent-Type: image/jpeg\r\n\r\n"),
+      frame,
+      Buffer.from("\r\n--frame\r\n"),
+      Buffer.from([0xff, 0xd8, 4, 5, 0xff, 0xd9]),
+    ]);
+
+    expect(extractFirstJpegFrame(buffer)?.equals(frame)).toBe(true);
+  });
+
+  it("returns null when no complete JPEG frame exists", () => {
+    expect(extractFirstJpegFrame(Buffer.from([0xff, 0xd8, 1, 2, 3]))).toBeNull();
+  });
+});

--- a/packages/server/src/routes/admin/avatars.ts
+++ b/packages/server/src/routes/admin/avatars.ts
@@ -4,6 +4,7 @@ import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { ALL_ACTIONS } from "shared";
 import { db } from "../../db";
 import { messages, petAvatars, petAvatarActions, pets, users } from "../../db/schema";
+import { extractFirstJpegFrame } from "../../utils/mjpeg";
 import { isManagedStorageUrl, normalizePublicFileUrl, uploadFile } from "../../utils/storage";
 import { broadcast } from "../../ws";
 
@@ -23,6 +24,7 @@ const ADMIN_TIME_ZONE = "Asia/Shanghai";
 const MAX_ACTION_VIDEO_SIZE = 50 * 1024 * 1024;
 const ACTION_VIDEO_TYPES = new Set(["video/mjpeg", "video/x-motion-jpeg"]);
 type AvatarStatus = (typeof petAvatars.$inferSelect)["status"];
+type AvatarAction = typeof petAvatarActions.$inferSelect;
 
 type AvatarRow = {
   avatar: typeof petAvatars.$inferSelect;
@@ -88,6 +90,14 @@ function toAvatarResponse(row: AvatarRow) {
   };
 }
 
+function toActionResponse(action: AvatarAction) {
+  return {
+    ...action,
+    imageUrl: normalizePublicFileUrl(action.imageUrl) ?? action.imageUrl,
+    videoUrl: normalizePublicFileUrl(action.videoUrl) ?? action.videoUrl,
+  };
+}
+
 async function getAvatarRow(avatarId: string) {
   const [row] = await db
     .select({
@@ -120,11 +130,7 @@ async function getAvatarActions(avatarId: string) {
     .where(eq(petAvatarActions.petAvatarId, avatarId))
     .orderBy(asc(petAvatarActions.sortOrder), asc(petAvatarActions.actionType), asc(petAvatarActions.id));
 
-  return actions.map((action) => ({
-    ...action,
-    imageUrl: normalizePublicFileUrl(action.imageUrl) ?? action.imageUrl,
-    videoUrl: normalizePublicFileUrl(action.videoUrl) ?? action.videoUrl,
-  }));
+  return actions.map(toActionResponse);
 }
 
 function resolveActionVideoContentType(file: File) {
@@ -387,9 +393,11 @@ avatarsRoute.put("/avatars/:id/meta", async (c) => {
 
 avatarsRoute.post("/avatars/:id/actions", async (c) => {
   const avatarId = c.req.param("id");
-  const body = await c.req.json<{ actionType?: string; imageUrl?: string }>();
+  const body = await c.req.json<{ actionType?: string; imageUrl?: string; videoUrl?: string | null }>();
   const actionType = body.actionType;
   const imageUrl = body.imageUrl;
+  const hasVideoUrl = Object.prototype.hasOwnProperty.call(body, "videoUrl");
+  const videoUrl = body.videoUrl ?? null;
 
   if (typeof actionType !== "string" || !VALID_ACTIONS.has(actionType)) {
     return c.json({ error: "Invalid actionType" }, 400);
@@ -397,6 +405,10 @@ avatarsRoute.post("/avatars/:id/actions", async (c) => {
 
   if (typeof imageUrl !== "string" || !isManagedStorageUrl(imageUrl)) {
     return c.json({ error: "Invalid imageUrl" }, 400);
+  }
+
+  if (hasVideoUrl && videoUrl !== null && (typeof videoUrl !== "string" || !isManagedStorageUrl(videoUrl))) {
+    return c.json({ error: "Invalid videoUrl" }, 400);
   }
 
   const row = await getAvatarRow(avatarId);
@@ -433,6 +445,7 @@ avatarsRoute.post("/avatars/:id/actions", async (c) => {
           .update(petAvatarActions)
           .set({
             imageUrl,
+            ...(hasVideoUrl ? { videoUrl } : {}),
           })
           .where(eq(petAvatarActions.id, existingAction.id))
           .returning()
@@ -442,6 +455,7 @@ avatarsRoute.post("/avatars/:id/actions", async (c) => {
             petAvatarId: avatarId,
             actionType,
             imageUrl,
+            videoUrl,
             sortOrder: (lastAction?.sortOrder ?? -1) + 1,
           })
           .returning();
@@ -460,7 +474,7 @@ avatarsRoute.post("/avatars/:id/actions", async (c) => {
   });
 
   return c.json({
-    action,
+    action: toActionResponse(action),
     avatarStatus: avatar?.status ?? (row.avatar.status === "approved" ? "processing" : row.avatar.status),
   });
 });
@@ -548,25 +562,37 @@ avatarsRoute.post("/avatars/:id/actions/:actionId/video", async (c) => {
     }
 
     const buffer = Buffer.from(await uploadedFile.arrayBuffer());
+    const thumbnailBuffer = extractFirstJpegFrame(buffer);
+
+    if (!thumbnailBuffer) {
+      return c.json({ error: "无法从 MJPEG 文件中提取首帧" }, 400);
+    }
+
     const videoHash = createHash("sha256").update(buffer).digest("hex");
     const videoUrl = await uploadFile(
       `avatars/${avatarId}/${action.actionType}.mjpeg`,
       buffer,
       contentType,
     );
+    const imageUrl = await uploadFile(
+      `avatars/${avatarId}/${action.actionType}-thumb.jpg`,
+      thumbnailBuffer,
+      "image/jpeg",
+    );
 
     const [updatedAction] = await db
       .update(petAvatarActions)
-      .set({ videoUrl, videoHash })
+      .set({ imageUrl, videoUrl, videoHash })
       .where(and(eq(petAvatarActions.id, actionId), eq(petAvatarActions.petAvatarId, avatarId)))
       .returning();
 
     return c.json({
-      action: {
+      action: toActionResponse({
         ...(updatedAction ?? action),
+        imageUrl,
         videoUrl,
         videoHash,
-      },
+      }),
     });
   } catch (error) {
     console.error("Admin action video upload failed:", error);

--- a/packages/server/src/routes/admin/upload.ts
+++ b/packages/server/src/routes/admin/upload.ts
@@ -1,11 +1,12 @@
 import { Hono } from "hono";
 import { createId } from "../../utils/id";
+import { extractFirstJpegFrame } from "../../utils/mjpeg";
 import { uploadFile } from "../../utils/storage";
 
 const adminUploadRoute = new Hono();
 
-const ALLOWED_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
-const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const ALLOWED_TYPES = new Set(["image/jpeg", "image/png", "image/webp", "video/mjpeg", "video/x-motion-jpeg"]);
+const MAX_FILE_SIZE = 50 * 1024 * 1024;
 
 adminUploadRoute.post("/upload", async (c) => {
   try {
@@ -19,11 +20,11 @@ adminUploadRoute.post("/upload", async (c) => {
     const uploadedFile = file as File;
 
     if (!ALLOWED_TYPES.has(uploadedFile.type)) {
-      return c.json({ error: "不支持的文件格式，请上传 JPG/PNG/WEBP 图片" }, 400);
+      return c.json({ error: "不支持的文件格式，请上传 JPG/PNG/WEBP/MJPEG 文件" }, 400);
     }
 
     if (uploadedFile.size > MAX_FILE_SIZE) {
-      return c.json({ error: "文件过大，请上传 10MB 以内的图片" }, 400);
+      return c.json({ error: "文件过大，请上传 50MB 以内的素材" }, 400);
     }
 
     const fileId = createId();
@@ -32,13 +33,30 @@ adminUploadRoute.post("/upload", async (c) => {
         ? "png"
         : uploadedFile.type === "image/webp"
           ? "webp"
-          : "jpg";
+          : uploadedFile.type === "video/mjpeg" || uploadedFile.type === "video/x-motion-jpeg"
+            ? "mjpeg"
+            : "jpg";
     const key = `admin/customization/${fileId}.${ext}`;
     const buffer = Buffer.from(await uploadedFile.arrayBuffer());
+    const isMjpeg = uploadedFile.type === "video/mjpeg" || uploadedFile.type === "video/x-motion-jpeg";
+    const thumbnailBuffer = isMjpeg ? extractFirstJpegFrame(buffer) : null;
+
+    if (isMjpeg && !thumbnailBuffer) {
+      return c.json({ error: "无法从 MJPEG 文件中提取首帧" }, 400);
+    }
 
     let url: string;
+    let thumbnailUrl: string | null = null;
     try {
       url = await uploadFile(key, buffer, uploadedFile.type);
+
+      if (thumbnailBuffer) {
+        thumbnailUrl = await uploadFile(
+          key.replace(/\.[^.]+$/, "-thumb.jpg"),
+          thumbnailBuffer,
+          "image/jpeg",
+        );
+      }
     } catch (error) {
       console.error("Admin storage upload failed:", error);
       const msg = error instanceof Error && error.message.includes("bucket")
@@ -47,7 +65,7 @@ adminUploadRoute.post("/upload", async (c) => {
       return c.json({ error: msg }, 503);
     }
 
-    return c.json({ url, fileId }, 201);
+    return c.json({ url, thumbnailUrl, fileId }, 201);
   } catch (error) {
     console.error("Admin upload failed:", error);
     return c.json({ error: "文件上传失败，请稍后重试" }, 503);

--- a/packages/server/src/routes/admin/uploads.ts
+++ b/packages/server/src/routes/admin/uploads.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { createId } from "../../utils/id";
+import { extractFirstJpegFrame } from "../../utils/mjpeg";
 import { ALLOWED_IMAGE_CONTENT_TYPES, createPresignedPutUrl, uploadFile } from "../../utils/storage";
 
 const uploadsRoute = new Hono();
@@ -62,10 +63,23 @@ uploadsRoute.post("/uploads", async (c) => {
     const ext = ALLOWED_IMAGE_CONTENT_TYPES[resolvedContentType];
     const key = `uploads/admin/${new Date().getUTCFullYear()}/${String(new Date().getUTCMonth() + 1).padStart(2, "0")}/${fileId}.${ext}`;
     const buffer = Buffer.from(await uploadedFile.arrayBuffer());
+    const isMjpeg = resolvedContentType === "video/mjpeg" || resolvedContentType === "video/x-motion-jpeg";
+    const thumbnailBuffer = isMjpeg ? extractFirstJpegFrame(buffer) : null;
+
+    if (isMjpeg && !thumbnailBuffer) {
+      return c.json({ error: "无法从 MJPEG 文件中提取首帧" }, 400);
+    }
 
     try {
       const url = await uploadFile(key, buffer, resolvedContentType);
-      return c.json({ url, fileId }, 201);
+      let thumbnailUrl: string | null = null;
+
+      if (thumbnailBuffer) {
+        const thumbnailKey = key.replace(/\.[^.]+$/, "-thumb.jpg");
+        thumbnailUrl = await uploadFile(thumbnailKey, thumbnailBuffer, "image/jpeg");
+      }
+
+      return c.json({ url, thumbnailUrl, fileId }, 201);
     } catch (error) {
       console.error("Admin media upload failed:", error);
       const msg = error instanceof Error && error.message.includes("bucket")

--- a/packages/server/src/routes/pets.ts
+++ b/packages/server/src/routes/pets.ts
@@ -12,6 +12,7 @@ import {
 } from "../db/schema";
 import { eq, and, isNull, inArray, gte, lte, desc, sql } from "drizzle-orm";
 import type { PetLatestBehavior } from "shared";
+import { normalizePublicFileUrl } from "../utils/storage";
 import { interactionRangeSchema } from "../validators/user-end";
 
 const petsRoute = new Hono();
@@ -133,6 +134,14 @@ function attachPetSummary<T extends typeof pets.$inferSelect>(
     latestBehavior: latestBehaviorMap.get(pet.id) ?? null,
     avatarImageUrl: latestAvatarImageMap.get(pet.id) ?? null,
   }));
+}
+
+function toPetAvatarActionResponse(action: typeof petAvatarActions.$inferSelect) {
+  return {
+    ...action,
+    imageUrl: normalizePublicFileUrl(action.imageUrl) ?? action.imageUrl,
+    videoUrl: normalizePublicFileUrl(action.videoUrl) ?? action.videoUrl,
+  };
 }
 
 function getStartOfLocalDay(date: Date) {
@@ -410,7 +419,11 @@ petsRoute.get("/:id", async (c) => {
   // TODO: 活跃值算法待产品定义，当前简单按行为次数映射 0-100
   const activityScore = Math.min(100, recentCount * 10);
 
-  return c.json({ pet: { ...pet, activityScore, latestBehavior }, avatars, actions });
+  return c.json({
+    pet: { ...pet, activityScore, latestBehavior },
+    avatars,
+    actions: actions.map(toPetAvatarActionResponse),
+  });
 });
 
 // 创建宠物

--- a/packages/server/src/utils/mjpeg.ts
+++ b/packages/server/src/utils/mjpeg.ts
@@ -1,0 +1,22 @@
+export function extractFirstJpegFrame(buffer: Buffer): Buffer | null {
+  let start = -1;
+
+  for (let index = 0; index < buffer.length - 1; index += 1) {
+    if (buffer[index] === 0xff && buffer[index + 1] === 0xd8) {
+      start = index;
+      break;
+    }
+  }
+
+  if (start === -1) {
+    return null;
+  }
+
+  for (let index = start + 2; index < buffer.length - 1; index += 1) {
+    if (buffer[index] === 0xff && buffer[index + 1] === 0xd9) {
+      return buffer.subarray(start, index + 2);
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## 概述

实现 issue #89 的后端改动：后台动作素材统一支持 MJPEG 视频，同时生成和返回首帧缩略图。

## 关键改动

- 新增 MJPEG 首帧 JPEG 提取工具，不依赖 ffmpeg
- 后台素材上传接口保存 MJPEG 原文件，并额外保存 `-thumb.jpg` 缩略图，返回 `url` 和 `thumbnailUrl`
- 管理后台动作素材创建/更新支持同时写入 `imageUrl` 和 `videoUrl`，动作视频上传同步更新缩略图
- 小程序宠物详情动作素材返回归一化后的 `imageUrl` 和 `videoUrl`
- 新增 0011 drizzle 数据迁移，回填旧 `image_url` 到 `video_url`
- 补充 MJPEG 提取和上传相关测试

## 验证

- `pnpm --filter server typecheck`
- `pnpm --filter server test`

Closes #89