### PR TITLE
fix(deploy): 挂载 docker 凭据让 watchtower 能拉取 GHCR 镜像

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -68,6 +68,9 @@ services:
       WATCHTOWER_LABEL_ENABLE: "true"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      # 挂载主机的 docker 凭据以便对私有 GHCR 镜像执行 HEAD digest 检查；
+      # 缺失会导致 watchtower 持续 403、updated=0，无法热更新。
+      - ${HOME}/.docker/config.json:/config.json:ro
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 


### PR DESCRIPTION
## Bug 描述
watchtower 长期处于"看似在跑、其实没更新"状态。每次轮询日志都是：
\`\`\`
Digest retrieval failed, falling back to full pull
error=\"registry responded with invalid HEAD request: status 403 Forbidden\"
Update session completed failed=0 scanned=N updated=0
\`\`\`
导致每次 PR 合并 → CI 推 GHCR 镜像后，线上不会自动更新，必须手动 ssh 上去 \`docker compose up -d\` 重建容器。

## 根因
GHCR 即使是 public 镜像，对 manifest 的 HEAD 请求也要求 token。watchtower 容器没有任何 GHCR 凭据，所以 HEAD 永远 403；声称"fallback to full pull"实际也失败，因此 updated 永远是 0。

## 修复
挂载主机的 \`~/.docker/config.json\` 到容器内 \`/config.json\`（watchtower 默认读这个路径）。主机上已经有 \`docker login ghcr.io\` 留下的 PAT 凭据，挂上即可。

\`\`\`yaml
volumes:
  - /var/run/docker.sock:/var/run/docker.sock
  - \${HOME}/.docker/config.json:/config.json:ro    # 新增
\`\`\`

## 验证
直接在线上服务器应用 patch 并重建 watchtower：
- 修复前轮询日志（每 5 分钟一次）：所有容器都报 403 + fallback
- 修复后轮询日志：\`Update session completed scanned=2 updated=0\`，无 403、无 fallback、无 warning

## 部署说明
合并后需要在服务器上执行：
\`\`\`
cd ~/pet-wechat && git pull && docker compose -f docker-compose.prod.yml up -d --no-deps watchtower
\`\`\`
（线上已经手动应用过同等改动，镜像里的修复将与现状一致。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)