### PR TITLE
[codex] Add desktop heartbeat timeout status

### DIFF
--- a/packages/server/src/__tests__/devices.test.ts
+++ b/packages/server/src/__tests__/devices.test.ts
@@ -257,6 +257,29 @@ describe("Device Routes", () => {
         },
       ]);
     });
+
+    it("returns stale online desktops as offline after 10 minutes without heartbeat", async () => {
+      mockDb._results.select = [[
+        {
+          desktop: fakeDesktop({
+            status: "online",
+            lastOnlineAt: new Date(Date.now() - 11 * 60 * 1000),
+          }),
+          bindingId: null,
+          bindingPetId: null,
+          bindingType: null,
+        },
+      ]];
+
+      const headers = await authHeader("user-1");
+      const res = await app.request(
+        jsonReq("GET", "/api/devices/desktops", { headers })
+      );
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.desktops[0].status).toBe("offline");
+    });
   });
 
   describe("POST /api/devices/desktops", () => {
@@ -335,6 +358,55 @@ describe("Device Routes", () => {
       expect(json.devices[0].usageDurationMinutes).toBe(180);
       expect(json.devices[0].isInactive).toBe(true);
       expect(json.devices[0].claimStatus).toBe("occupied");
+    });
+
+    it("derives desktop offline state from a 10 minute heartbeat timeout", async () => {
+      mockDb._results.select = [
+        [],
+        [
+          {
+            desktop: fakeDesktop({
+              status: "online",
+              lastOnlineAt: new Date(Date.now() - 11 * 60 * 1000),
+            }),
+            bindingId: null,
+            bindingPetId: null,
+            bindingType: null,
+          },
+        ],
+      ];
+
+      const headers = await authHeader("user-1");
+      const res = await app.request(jsonReq("GET", "/api/devices", { headers }));
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.devices[0].deviceType).toBe("desktop");
+      expect(json.devices[0].status).toBe("offline");
+    });
+
+    it("keeps recently heartbeating desktops online", async () => {
+      mockDb._results.select = [
+        [],
+        [
+          {
+            desktop: fakeDesktop({
+              status: "online",
+              lastOnlineAt: new Date(Date.now() - 9 * 60 * 1000),
+            }),
+            bindingId: null,
+            bindingPetId: null,
+            bindingType: null,
+          },
+        ],
+      ];
+
+      const headers = await authHeader("user-1");
+      const res = await app.request(jsonReq("GET", "/api/devices", { headers }));
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.devices[0].status).toBe("online");
     });
   });
 

--- a/packages/server/src/routes/admin/devices.ts
+++ b/packages/server/src/routes/admin/devices.ts
@@ -14,6 +14,7 @@ import { ALL_ACTIONS } from "shared";
 import { db } from "../../db";
 import { users, pets, collarDevices, desktopDevices, desktopPetBindings, petAvatars, petBehaviors } from "../../db/schema";
 import { createId } from "../../utils/id";
+import { getEffectiveDeviceStatus } from "../../utils/device-status";
 import { normalizeMac, NORMALIZED_MAC_REGEX } from "../../utils/mac";
 import { buildPageResponse, parsePagination } from "../../utils/pagination";
 import { normalizePublicFileUrl } from "../../utils/storage";
@@ -239,7 +240,11 @@ function toAdminDeviceListItem(row: RawDeviceRow): AdminDeviceListItem {
     name: row.name,
     chipId: row.chip_id,
     macAddress: row.mac_address,
-    status: row.status,
+    status: getEffectiveDeviceStatus({
+      type: row.type,
+      status: row.status,
+      lastOnlineAt: row.last_online_at,
+    }),
     claimStatus: row.claim_status,
     upgradeStatus: row.upgrade_status,
     firmwareVersion: row.firmware_version,
@@ -267,7 +272,11 @@ function toAdminDeviceRelationItem(row: RawRelatedDeviceRow): AdminDeviceRelatio
     type: row.type,
     id: row.id,
     name: row.name,
-    status: row.status,
+    status: getEffectiveDeviceStatus({
+      type: row.type,
+      status: row.status,
+      lastOnlineAt: row.last_online_at,
+    }),
     claimStatus: row.claim_status,
     lastOnlineAt: toIsoString(row.last_online_at),
     createdAt: toRequiredIsoString(row.created_at),

--- a/packages/server/src/routes/devices.ts
+++ b/packages/server/src/routes/devices.ts
@@ -14,6 +14,7 @@ import {
 import { eq, and, isNull, desc } from "drizzle-orm";
 import { generateInviteCode, verifyInviteCode } from "../utils/invite";
 import { normalizeMac, NORMALIZED_MAC_REGEX } from "../utils/mac";
+import { getEffectiveDeviceStatus } from "../utils/device-status";
 import { deviceTypeSchema } from "../validators/user-end";
 
 const devicesRoute = new Hono();
@@ -157,6 +158,11 @@ async function getOwnedDesktops(userId: string) {
 
     desktops.set(row.desktop.id, {
       ...row.desktop,
+      status: getEffectiveDeviceStatus({
+        type: "desktop",
+        status: row.desktop.status,
+        lastOnlineAt: row.desktop.lastOnlineAt,
+      }),
       bindings:
         row.bindingId && row.bindingPetId && row.bindingType
           ? [
@@ -607,7 +613,11 @@ devicesRoute.get("/", async (c) => {
       deviceId: collar.id,
       deviceType: "collar" as const,
       name: collar.name,
-      status: collar.status,
+      status: getEffectiveDeviceStatus({
+        type: "collar",
+        status: collar.status,
+        lastOnlineAt: collar.lastOnlineAt,
+      }),
       firmwareVersion: collar.firmwareVersion,
       claimStatus: collar.claimStatus,
       usageDurationMinutes: collar.usageDurationMinutes,
@@ -621,7 +631,11 @@ devicesRoute.get("/", async (c) => {
       deviceId: desktop.id,
       deviceType: "desktop" as const,
       name: desktop.name,
-      status: desktop.status,
+      status: getEffectiveDeviceStatus({
+        type: "desktop",
+        status: desktop.status,
+        lastOnlineAt: desktop.lastOnlineAt,
+      }),
       firmwareVersion: desktop.firmwareVersion,
       claimStatus: desktop.claimStatus,
       usageDurationMinutes: desktop.usageDurationMinutes,

--- a/packages/server/src/utils/device-status.ts
+++ b/packages/server/src/utils/device-status.ts
@@ -1,0 +1,26 @@
+import type { DeviceStatus, DeviceType } from "shared";
+
+export const DEVICE_ONLINE_TIMEOUT_MS = 10 * 60 * 1000;
+
+export function getEffectiveDeviceStatus(options: {
+  type: DeviceType;
+  status: DeviceStatus;
+  lastOnlineAt: Date | string | null | undefined;
+  now?: Date;
+}): DeviceStatus {
+  if (options.type !== "desktop" || options.status !== "online") {
+    return options.status;
+  }
+
+  if (!options.lastOnlineAt) {
+    return "offline";
+  }
+
+  const lastOnlineTime = new Date(options.lastOnlineAt).getTime();
+  if (Number.isNaN(lastOnlineTime)) {
+    return "offline";
+  }
+
+  const nowTime = options.now?.getTime() ?? Date.now();
+  return nowTime - lastOnlineTime > DEVICE_ONLINE_TIMEOUT_MS ? "offline" : "online";
+}


### PR DESCRIPTION
## Summary

- Add a shared backend status helper that treats desktop devices as offline when their latest heartbeat is older than 10 minutes.
- Apply the derived status to mini-program device APIs and admin device list/relation responses.
- Cover stale and recent desktop heartbeat behavior in device route tests.

## Why

Desktop devices report heartbeat about once per minute. Previously a device could remain displayed as online indefinitely if it stopped reporting without sending an explicit offline status.

## Validation

- `bun test src/__tests__/devices.test.ts`
- `bun test src/__tests__/admin-devices.test.ts`
- `pnpm --filter server typecheck`
