### PR TITLE
fix(ci): 修复 GHCR 推送 403，镜像 prefix 改为 astromnic-ai

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ghcr.io/thup-jds/pet-wechat
+  IMAGE_PREFIX: ghcr.io/astromnic-ai/pet-wechat
 
 permissions:
   contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,11 +132,11 @@ NODE
 
 - `postgres` - PostgreSQL 16
 - `minio` - MinIO 对象存储（S3 兼容）
-- `server` - 后端 API + 管理后台 SPA（镜像来自 GHCR：`ghcr.io/thup-jds/pet-wechat/server`）
+- `server` - 后端 API + 管理后台 SPA（镜像来自 GHCR：`ghcr.io/astromnic-ai/pet-wechat/server`）
 
 ### 管理后台镜像合并
 
-管理后台不再单独构建 nginx 镜像，也不再由 `docker-compose.prod.yml` 启动 `admin` 服务。CI 只构建 `ghcr.io/thup-jds/pet-wechat/server`，该镜像内置 `packages/admin` 的构建产物，由 Hono/Bun 在 9527 端口提供 SPA 静态资源和路由 fallback。
+管理后台不再单独构建 nginx 镜像，也不再由 `docker-compose.prod.yml` 启动 `admin` 服务。CI 只构建 `ghcr.io/astromnic-ai/pet-wechat/server`，该镜像内置 `packages/admin` 的构建产物，由 Hono/Bun 在 9527 端口提供 SPA 静态资源和路由 fallback。
 
 部署时需要手动调整 Caddy：将 `pet-admin.yangl.com.cn` 从原来的 `admin:80` / `localhost:9528` 改为反代到 `server:9527` / `localhost:9527`。
 
@@ -149,5 +149,5 @@ NODE
 ### 微信小程序
 
 - AppID：`wx29ab8d3fd0cb4af0`
-- GitHub 组织：`thup-jds/pet-wechat`
+- GitHub 仓库：`astromnic-ai/pet-wechat`
 - CI：GitHub Actions 构建 Docker 镜像推送到 GHCR

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,7 +32,7 @@ services:
       retries: 5
 
   server:
-    image: ghcr.io/thup-jds/pet-wechat/server:latest
+    image: ghcr.io/astromnic-ai/pet-wechat/server:latest
     restart: unless-stopped
     ports:
       - "9527:9527"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - minio_data:/data
 
   server:
-    image: ghcr.io/thup-jds/pet-wechat/server:latest
+    image: ghcr.io/astromnic-ai/pet-wechat/server:latest
     ports:
       - "9527:9527"
     environment:
@@ -41,7 +41,7 @@ services:
       - minio
 
   admin:
-    image: ghcr.io/thup-jds/pet-wechat/admin:latest
+    image: ghcr.io/astromnic-ai/pet-wechat/admin:latest
     ports:
       - "80:80"
     depends_on:


### PR DESCRIPTION
## Summary

- 仓库实际在 `astromnic-ai/pet-wechat`，但 workflow 把镜像推到 `ghcr.io/thup-jds/pet-wechat/server`
- 默认 `GITHUB_TOKEN` 只对当前 org 的 packages 有写权限，跨 org 推送返回 403（PR #100 合并后的 build 因此失败、`:latest` 镜像 5 天没更新）
- 全部 prefix 改为 `ghcr.io/astromnic-ai/pet-wechat`：workflow + 两个 docker-compose + CLAUDE.md

## Test plan

- [ ] 合并后 CI 应推成功到 `ghcr.io/astromnic-ai/pet-wechat/server:latest`
- [ ] Watchtower 自动拉取新镜像（5 分钟轮询）
- [ ] 若 Watchtower 不工作，服务器手动 `docker compose pull server && docker compose up -d server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)